### PR TITLE
Replace K&R signatures with ANSI signatures

### DIFF
--- a/src/Game/game.h
+++ b/src/Game/game.h
@@ -143,7 +143,7 @@ static inline void GM_Sound(int byte_2, int byte_1, int byte_0)
     }
 }
 
-static inline void GM_SetCurrentMap(map) int map;
+static inline void GM_SetCurrentMap(int map)
 {
     GM_CurrentMap_800AB9B0 = map;
 }

--- a/src/libdg/libdg.h
+++ b/src/libdg/libdg.h
@@ -441,55 +441,53 @@ static inline void SCOPYL2( void *s1, void *d1, void *s2, void *d2 )
 	*(u_short *)d2 = r2;
 }
 
-static inline void DG_VisibleObjs( objs ) DG_OBJS *objs;
+static inline void DG_VisibleObjs( DG_OBJS *objs )
 {
 	objs->flag &= ~DG_FLAG_INVISIBLE;
 }
 
-static inline void DG_InvisibleObjs( objs ) DG_OBJS *objs;
+static inline void DG_InvisibleObjs( DG_OBJS *objs )
 {
 	objs->flag |= DG_FLAG_INVISIBLE;
 }
 
-static inline void DG_GroupObjs( objs, group_id ) DG_OBJS *objs;
-int                group_id;
+static inline void DG_GroupObjs( DG_OBJS *objs, int group_id )
 {
 	objs->group_id = group_id;
 }
 
-static inline void DG_GroupPrim( prim, group_id ) DG_PRIM *prim;
-int                group_id;
+static inline void DG_GroupPrim( DG_PRIM *prim, int group_id )
 {
 	prim->group_id = group_id;
 }
 
-static inline void DG_VisiblePrim( prim ) DG_PRIM *prim;
+static inline void DG_VisiblePrim( DG_PRIM *prim )
 {
 	prim->type &= ~DG_PRIM_INVISIBLE;
 }
 
-static inline void DG_InvisiblePrim( prim ) DG_PRIM *prim;
+static inline void DG_InvisiblePrim( DG_PRIM *prim )
 {
 	prim->type |= DG_PRIM_INVISIBLE;
 }
 
 
-static inline void DG_UnShadeObjs( objs ) DG_OBJS *objs;
+static inline void DG_UnShadeObjs( DG_OBJS *objs )
 {
 	objs->flag &= ~DG_FLAG_SHADE;
 }
 
-static inline void DG_UnBoundObjs( objs ) DG_OBJS *objs;
+static inline void DG_UnBoundObjs( DG_OBJS *objs )
 {
 	objs->flag &= ~DG_FLAG_BOUND;
 }
 
-static inline void DG_UnGBoundObjs( objs ) DG_OBJS *objs;
+static inline void DG_UnGBoundObjs( DG_OBJS *objs )
 {
 	objs->flag &= ~DG_FLAG_GBOUND;
 }
 
-static inline void DG_GBoundObjs( objs ) DG_OBJS *objs;
+static inline void DG_GBoundObjs( DG_OBJS *objs )
 {
 	objs->flag |= DG_FLAG_GBOUND;
 }


### PR DESCRIPTION
decomp.me decompiler struggles with them. In the past we already replaced some K&R signatures with ANSI signatures: 62ac34cf72e88fb44e8d51858901bc31312d1b90