### PR TITLE
Starting aligning functions with VR exe

### DIFF
--- a/build/build.py
+++ b/build/build.py
@@ -84,6 +84,9 @@ def ninja_run():
         r'select\.c:\d+: warning: `gcl_string\' might be used uninitialized in this function',
     ]
 
+    if args.variant == 'vr_exe':
+        warning_whitelist += [r'control reaches end of non-void function']
+
     if os.environ.get('APPVEYOR'):
         with subprocess.Popen([ninja] + ninja_args, stdout=subprocess.PIPE, encoding='utf8') as proc:
             for line in proc.stdout:
@@ -334,6 +337,9 @@ def gen_build_target(targetName):
         "select",
         "d11c"
     ]
+
+    if args.variant == 'vr_exe':
+        OVERLAYS = [None]
 
     for overlay in OVERLAYS:
         suffix = f"_{overlay}" if overlay else ""

--- a/src/Game/alert.c
+++ b/src/Game/alert.c
@@ -97,10 +97,14 @@ int GM_GetNoiseSound_8002E614(int arg0, int arg1)
 
 void GM_SoundStart_8002E640(void)
 {
+#ifndef VR_EXE
     if (dword_800ABA70 == 0)
     {
         sub_8002E508(dword_800ABA78[GM_AlertMode_800ABA00 != 0]);
     }
+#else
+    TEMPORARY_VR_MATCHING_PLACEHOLDER(0, 0, 1, 5);
+#endif
 }
 
 //AlertCmd() ?

--- a/src/Game/area.c
+++ b/src/Game/area.c
@@ -30,8 +30,9 @@ void GM_SetAreaHistory_8002A784(AreaHistory *pNewHistory)
     gAreaHistory_800B5850 = *pNewHistory;
 }
 
-int GM_SetArea_8002A7D8(int stage_id, char *pStageName)
+int GM_SetArea_8002A7D8(int stage_id, char *pStageName) // different in VR
 {
+#ifndef VR_EXE
     int i;
 
     sCurrentAreaName_800AB9C0 = stage_id;
@@ -42,6 +43,9 @@ int GM_SetArea_8002A7D8(int stage_id, char *pStageName)
     }
     gAreaHistory_800B5850.history[0] = stage_id;
     return stage_id;
+#else
+    TEMPORARY_VR_MATCHING_PLACEHOLDER(0, 0, 2, 5);
+#endif
 }
 
 int GM_AreaHistory_8002A848(int stage_id)
@@ -58,7 +62,11 @@ int GM_AreaHistory_8002A848(int stage_id)
     return i;
 }
 
-char *GM_GetArea_8002A880(int unused)
+char *GM_GetArea_8002A880(int unused) // different in VR
 {
+#ifndef VR_EXE
     return gCurrentStageName_800AB3C4;
+#else
+    TEMPORARY_VR_MATCHING_PLACEHOLDER(0, 0, 0, 1);
+#endif
 }

--- a/src/Game/camera.c
+++ b/src/Game/camera.c
@@ -541,6 +541,7 @@ void camera_act_helper3_8002F64C(void)
 
 void camera_act_helper4_8002F78C(void)
 {
+#ifndef VR_EXE
     SVECTOR vec;
 
     gUnkCameraStruct2_800B7868.field_20 = 0;
@@ -614,6 +615,9 @@ void camera_act_helper4_8002F78C(void)
         gUnkCameraStruct2_800B7868.eye.vy += GM_CameraShakeOffset_800ABA98 / 4;
         GM_CameraShakeOffset_800ABA98 = 0;
     }
+#else
+    TEMPORARY_VR_MATCHING_PLACEHOLDER(0, 1, 9, 6);
+#endif
 }
 
 void sub_8002FAAC(SVECTOR *a1, SVECTOR *a2, SVECTOR *a3, int *a4)
@@ -674,6 +678,7 @@ void sub_8002FCA4(SVECTOR *param_1, SVECTOR *param_2, SVECTOR *param_3, int *par
 
 void sub_8002FCF0(void)
 {
+#ifndef VR_EXE
     if (!(GM_Camera_800B77E8.field_18_flags & 0x20))
     {
         gUnkCameraStruct_800B77B8.field_18 = GM_CameraTrackSave_800AB42C;
@@ -684,6 +689,9 @@ void sub_8002FCF0(void)
         gUnkCameraStruct_800B77B8.field_18 = gUnkCameraStruct2_800B76F0.field_18;
         gUnkCameraStruct_800B77B8.field_10 = gUnkCameraStruct2_800B76F0.field_10;
     }
+#else
+    TEMPORARY_VR_MATCHING_PLACEHOLDER(0, 0, 3, 4);
+#endif
 }
 
 void sub_8002FD84(int index, TGMCameraFunc func)
@@ -944,6 +952,7 @@ void sub_800303E0(SVECTOR *arg0)
 
 void sub_8003049C(SVECTOR *a1)
 {
+#ifndef VR_EXE
     GM_Camera *pCamera;
 
     pCamera = &GM_Camera_800B77E8;
@@ -961,10 +970,14 @@ void sub_8003049C(SVECTOR *a1)
     GV_AddVec3_80016D00(&gUnkCameraStruct_800B77B8.field_8, a1, &gUnkCameraStruct_800B77B8.field_8);
 
     GV_AddVec3_80016D00(&svec_800ABA88, a1, &svec_800ABA88);
+#else
+    TEMPORARY_VR_MATCHING_PLACEHOLDER(0, 0, 6, 1);
+#endif
 }
 
 void camera_act_8003059C(GV_ACT *pActor)
 {
+#ifndef VR_EXE
     int iVar1;
     int iVar2;
 
@@ -1005,6 +1018,9 @@ void camera_act_8003059C(GV_ACT *pActor)
             &gUnkCameraStruct2_800B7868.center,
             gUnkCameraStruct2_800B7868.clip_distance);
     }
+#else
+    TEMPORARY_VR_MATCHING_PLACEHOLDER(0, 0, 6, 2);
+#endif
 }
 
 GV_ACT *camera_init_800306A0()
@@ -1128,8 +1144,12 @@ void GCL_Command_camera_helper2_800308E0(SVECTOR *vec1, SVECTOR *vec2, int param
 
 void GCL_Command_camera_helper3_80030938(SVECTOR *pVec)
 {
+#ifndef VR_EXE
     GM_CameraRotateSave_800AB430 = *pVec;
     sub_8002FCF0();
+#else
+    TEMPORARY_VR_MATCHING_PLACEHOLDER(0, 0, 1, 5);
+#endif
 }
 
 void GCL_Command_camera_helper4_80030980(int param_1)
@@ -1148,9 +1168,13 @@ void GM_CameraEventReset_800309A8(void)
 
 void sub_800309B4(int param_1, int param_2)
 {
+#ifndef VR_EXE
     GM_Camera_800B77E8.field_2A = param_1;
     GM_Camera_800B77E8.field_26 = param_2;
     svec_800ABA88 = GM_Camera_800B77E8.field_0;
+#else
+    TEMPORARY_VR_MATCHING_PLACEHOLDER(0, 0, 1, 4);
+#endif
 }
 
 void sub_800309F8(int param_1, int param_2)

--- a/src/Game/script.c
+++ b/src/Game/script.c
@@ -552,8 +552,9 @@ int GCL_Command_start_8002C22C(unsigned char *pScript)
     return 0;
 }
 
-int GCL_Command_load_8002C308(unsigned char *pScript)
+int GCL_Command_load_8002C308(unsigned char *pScript) // different in VR
 {
+#ifndef VR_EXE
     char *scriptStageName;
     SVECTOR vec;
 
@@ -623,6 +624,9 @@ int GCL_Command_load_8002C308(unsigned char *pScript)
     }
 
     return 0;
+#else
+    TEMPORARY_VR_MATCHING_PLACEHOLDER(0, 1, 0, 0);
+#endif
 }
 
 int GCL_Command_radio_8002C4A8(unsigned char *pScript)
@@ -744,8 +748,13 @@ int GCL_Command_varsave_8002C72C(unsigned char *pScript)
     return 0;
 }
 
-int GCL_Command_system_8002C7C8(unsigned char *pScript)
+#ifdef VR_EXE
+const char const2[] = "SYSTEM:%c:change proc name\n";
+#endif
+
+int GCL_Command_system_8002C7C8(unsigned char *pScript) // different in VR
 {
+#ifndef VR_EXE
     int i, proc;
 
     for (i = 0; i <= (int)sizeof(aGcawi); i++)
@@ -767,6 +776,9 @@ int GCL_Command_system_8002C7C8(unsigned char *pScript)
         GM_StageName_800AB918 = GCL_Read_String_80020A70(GCL_Get_Param_Result_80020AA4());
     }
     return 0;
+#else
+    TEMPORARY_VR_MATCHING_PLACEHOLDER(0, 0, 4, 7);
+#endif
 }
 
 int GCL_Command_demo_8002C890(unsigned char *pScript)

--- a/src/Menu/datasave.c
+++ b/src/Menu/datasave.c
@@ -471,6 +471,7 @@ int init_file_mode_helper_helper_helper3_80049E94(int param_1)
 
 void init_file_mode_helper_helper_80049EDC(void)
 {
+#ifndef VR_EXE
     int temp_a0;
     int temp_a0_2;
     int temp_s0;
@@ -760,6 +761,10 @@ block_72:
 block_73:
         init_file_mode_helper_helper_helper3_80049E94(0xC5000002);
     }
+
+#else
+    TEMPORARY_VR_MATCHING_PLACEHOLDER(0, 3, 3, 0);
+#endif
 }
 
 void init_file_mode_helper_8004A424(int param_1)
@@ -1178,8 +1183,14 @@ void menu_radio_do_file_mode_helper8_8004AFE4(Actor_MenuMan *pActor, char *pOt, 
     addPrim(pOt, pPrim);
 }
 
+#ifdef VR_EXE
+char SECTION(".rdata") strin1[] = "NEW FILE [ NEED %d BLOCK%s ]";
+char SECTION(".rdata") strin2[] = "FREE: %d BLOCK%s";
+#endif
+
 void menu_radio_do_file_mode_save_memcard_8004B0A0(Actor_MenuMan *pActor, char *pOt, Stru_800ABB74 *pStru)
 {
+#ifndef VR_EXE
     TextConfig config;
 
     char saveid[16];
@@ -1502,6 +1513,9 @@ void menu_radio_do_file_mode_save_memcard_8004B0A0(Actor_MenuMan *pActor, char *
             menu_draw_triangle_800435EC(pActor->field_20_otBuf, &triangle_8009EBE0);
         }
     }
+#else
+    TEMPORARY_VR_MATCHING_PLACEHOLDER(0, 5, 3, 2);
+#endif
 }
 
 void menu_radio_do_file_mode_helper12_helper_8004B8FC(char *param_1, char *param_2)
@@ -1918,8 +1932,21 @@ int menu_radio_do_file_mode_helper17_8004C2E4(GV_PAD *pPad, int *outParam, Stru_
     return 0;
 }
 
+#ifdef VR_EXE
+const char SECTION(".rdata") aSaving[] = "SAVING...";
+const char SECTION(".rdata") aNoSpace[] = "NO SPACE";
+const char SECTION(".rdata") aLoadData[] = "LOAD DATA";
+const char SECTION(".rdata") aLoading[] = "LOADING...";
+const char SECTION(".rdata") aSelectMemoryCa[] = "SELECT MEMORY CARD";
+const char SECTION(".rdata") aPressToExit[] = "PRESS * TO EXIT";
+const char SECTION(".rdata") aPressToSelectM[] = "PRESS * TO SELECT MEMORY CARD";
+const char SECTION(".rdata") aEndSaveMode[] = "END SAVE MODE\n";
+const char SECTION(".rdata") aEndStateD[] = "END STATE %d\n";
+#endif
+
 int menu_radio_do_file_mode_8004C418(Actor_MenuMan *pActor, GV_PAD *pPad)
 {
+#ifndef VR_EXE
     TextConfig     textConfig1, textConfig2;
     int            res1, res2, res3;
     char         **strArr;
@@ -2229,12 +2256,10 @@ int menu_radio_do_file_mode_8004C418(Actor_MenuMan *pActor, GV_PAD *pPad)
                 font_set_color_80044DC4(pActor->field_214_font, 1, 0x3BEF, 0);
                 return 1;
             }
-
             return 2;
         }
         break;
     }
-
     if (dword_800ABB84 >= 2)
     {
         dword_800ABB84--;
@@ -2252,6 +2277,9 @@ int menu_radio_do_file_mode_8004C418(Actor_MenuMan *pActor, GV_PAD *pPad)
     }
     menu_radio_do_file_mode_helper6_8004AD40(pActor->field_20_otBuf);
     return 0;
+#else
+    TEMPORARY_VR_MATCHING_PLACEHOLDER(0, 6, 9, 9);
+#endif
 }
 
 extern char aAtEUC[];   // = "@";
@@ -2424,3 +2452,8 @@ void menu_radio_8004D35C(void)
 {
     sub_8004124C(&gMenuMan_800BD360);
 }
+
+#ifdef VR_EXE
+const int  SECTION(".rdata") jpt_8001230C[] = {0x8004C4E8, 0x8004C580, 0x8004CAF8, 0x8004CB7C,
+                                               0x8004CCD4, 0x8004CC34, 0x8004CDB4};
+#endif

--- a/src/Menu/life.c
+++ b/src/Menu/life.c
@@ -387,6 +387,7 @@ extern KCB  font_800BD968;
 
 int sub_8003F84C(int idx)
 {
+#ifndef VR_EXE
     void *font_buffer;
 
     setSprt(&gMenuSprt_800bd998);
@@ -421,6 +422,9 @@ int sub_8003F84C(int idx)
     font_set_color_80044DC4(&font_800BD968, 0, 0x6739, 0);
     font_clut_update_80046980(&font_800BD968);
     return 1;
+#else
+    TEMPORARY_VR_MATCHING_PLACEHOLDER(0, 0, 7, 1);
+#endif
 }
 
 void sub_8003F97C(char *string)

--- a/src/Menu/radar.c
+++ b/src/Menu/radar.c
@@ -813,8 +813,9 @@ void draw_radar_helper3_helper2_8003A2D0(MenuPrim *pGlue, int idx)
     }
 }
 
-void draw_radar_helper3_helper3_8003A664(MenuPrim *pGlue, int param_2, int code)
+void draw_radar_helper3_helper3_8003A664(MenuPrim *pGlue, int param_2, int code) // different in VR
 {
+#ifndef VR_EXE
     int       temp_v0_3;
     int       i, j;
     int       var_s2;
@@ -899,6 +900,9 @@ void draw_radar_helper3_helper3_8003A664(MenuPrim *pGlue, int param_2, int code)
     }
 
     draw_radar_helper3_helper3_helper_8003A0BC(pGlue, code);
+#else
+    TEMPORARY_VR_MATCHING_PLACEHOLDER(0, 1, 9, 1);
+#endif
 }
 
 void draw_radar_helper3_helper4_8003A978(MenuPrim *prim, int x, int code)
@@ -912,8 +916,9 @@ void draw_radar_helper3_helper4_8003A978(MenuPrim *prim, int x, int code)
     addPrim(prim->mPrimBuf.mOt, sprt);
 }
 
-void draw_radar_helper3_8003AA2C(Actor_MenuMan *pActor, char *pOt, int param_3, int param_4)
+void draw_radar_helper3_8003AA2C(Actor_MenuMan *pActor, char *pOt, int param_3, int param_4) // different in VR
 {
+#ifndef VR_EXE
     unsigned int randValue;
     DR_TPAGE    *tpage1;
     TILE        *tile;
@@ -979,6 +984,9 @@ void draw_radar_helper3_8003AA2C(Actor_MenuMan *pActor, char *pOt, int param_3, 
     NEW_PRIM(tpage2, pActor);
     setDrawTPage(tpage2, 1, 0, getTPage(0, 0, 960, 256));
     addPrim(pOt, tpage2);
+#else
+    TEMPORARY_VR_MATCHING_PLACEHOLDER(0, 2, 0, 3);
+#endif
 }
 
 void menu_radar_load_rpk_8003AD64()

--- a/src/Menu/radio.c
+++ b/src/Menu/radio.c
@@ -179,8 +179,9 @@ void menu_radio_codec_helper_helper16_8003FC54(Actor_MenuMan *pActor, unsigned c
     addPrim(pOt, tpage);
 }
 
-void sub_8003FD50(MenuPrim *pMenuPrim, int xoff, int yoff, int param_4, RadioUnknown *pRadioUnknown, int abe)
+void sub_8003FD50(MenuPrim *pMenuPrim, int xoff, int yoff, int param_4, RadioUnknown *pRadioUnknown, int abe) // different in VR
 {
+#ifndef VR_EXE
     int          bit;
     int          iVar1;
     int          i;
@@ -262,6 +263,9 @@ void sub_8003FD50(MenuPrim *pMenuPrim, int xoff, int yoff, int param_4, RadioUnk
         setSemiTrans(pLine, abe);
         addPrim(pMenuPrim->mPrimBuf.mOt, pLine);
     }
+#else
+    TEMPORARY_VR_MATCHING_PLACEHOLDER(0, 1, 4, 9);
+#endif
 }
 
 void menu_init_sprt_8003D0D0(SPRT *pPrim, PANEL_TEXTURE *pUnk, int offset_x, int offset_y);
@@ -760,8 +764,9 @@ void menu_radio_codec_helper_helper14_80040DC4(Actor_MenuMan *pActor, int param_
 extern RECT rect_800AB630;
 RECT        SECTION(".sdata") rect_800AB630;
 
-void init_radio_message_board_80040F74(Actor_MenuMan *pActor)
+void init_radio_message_board_80040F74(Actor_MenuMan *pActor) // different in VR
 {
+#ifndef VR_EXE
     KCB  local_kcb;
     KCB *allocated_kcb;
 
@@ -788,26 +793,38 @@ void init_radio_message_board_80040F74(Actor_MenuMan *pActor)
 
         dword_800ABB04 = NULL;
     }
+#else
+    TEMPORARY_VR_MATCHING_PLACEHOLDER(0, 0, 7, 8);
+#endif
 }
 
-void menu_radio_codec_helper__helper13_800410E4(Actor_MenuMan *pActor, char *string)
+void menu_radio_codec_helper__helper13_800410E4(Actor_MenuMan *pActor, char *string) // different in VR
 {
+#ifndef VR_EXE
     KCB *kcb = pActor->field_214_font;
     dword_800ABB04 = string;
     font_print_string_800469A4(kcb, string);
     font_update_8004695C(kcb);
+#else
+    TEMPORARY_VR_MATCHING_PLACEHOLDER(0, 0, 1, 1);
+#endif
 }
 
-void sub_80041118(Actor_MenuMan *pActor)
+void sub_80041118(Actor_MenuMan *pActor) // different in VR
 {
+#ifndef VR_EXE
     KCB *kcb = pActor->field_214_font;
     dword_800ABB04 = NULL;
     font_clear_800468FC(kcb);
     font_update_8004695C(kcb);
+#else
+    TEMPORARY_VR_MATCHING_PLACEHOLDER(0, 0, 1, 1);
+#endif
 }
 
-int draw_radio_message_8004114C(Actor_MenuMan *pActor, unsigned char *pOt)
+int draw_radio_message_8004114C(Actor_MenuMan *pActor, unsigned char *pOt) // different in VR
 {
+#ifndef VR_EXE
     KCB  *kcb;
     SPRT *pPrim;
 
@@ -833,14 +850,25 @@ int draw_radio_message_8004114C(Actor_MenuMan *pActor, unsigned char *pOt)
     setSprt(pPrim);
     addPrim(pOt, pPrim);
     return 1;
+#else
+    TEMPORARY_VR_MATCHING_PLACEHOLDER(0, 0, 6, 2);
+#endif
 }
 
-void sub_8004124C(Actor_MenuMan *pActor)
+void sub_8004124C(Actor_MenuMan *pActor) // different in VR
 {
+#ifndef VR_EXE
     GV_FreeMemory_80015FD0(0, pActor->field_214_font);
     pActor->field_214_font = NULL;
     dword_800ABB04 = NULL;
+#else
+    TEMPORARY_VR_MATCHING_PLACEHOLDER(0, 0, 2, 1);
+#endif
 }
+
+// nop count was incorrect to this point
+// was a new function added in VR?
+// or simply I made a counting mistake and no function was added
 
 int menu_radio_codec_helper_helper12_80041280(Actor_MenuMan *pActor, unsigned char *pOt, GV_PAD *pPad)
 {
@@ -1495,8 +1523,17 @@ void menu_radio_init_nullsub_80042190(Actor_MenuMan *pActor)
 {
 }
 
-void menu_radio_update_80042198(Actor_MenuMan *pActor, unsigned char *pOt)
+#ifdef VR_EXE
+const char SECTION(".rdata") str1[] = "GetPotion %d\n";
+const char SECTION(".rdata") str2[] = "PUSH SELECT";
+const char SECTION(".rdata") str3[] = "callback type %d proc %X\n";
+const char SECTION(".rdata") str5[] = "ExecProc\n";
+const char SECTION(".rdata") str4[] = "EXIT MUSENKI\n";
+#endif
+
+void menu_radio_update_80042198(Actor_MenuMan *pActor, unsigned char *pOt) // different in VR
 {
+#ifndef VR_EXE
     GCL_ARGS args;
     long     argv[2];
 
@@ -1512,7 +1549,6 @@ void menu_radio_update_80042198(Actor_MenuMan *pActor, unsigned char *pOt)
     {
         return;
     }
-
     if (state == 0)
     {
         if (!(GM_GameStatus_800AB3CC & (GAME_FLAG_BIT_06 | GAME_FLAG_BIT_11 | GAME_FLAG_BIT_14)) && GV_PauseLevel_800AB928 == 0)
@@ -1653,6 +1689,9 @@ void menu_radio_update_80042198(Actor_MenuMan *pActor, unsigned char *pOt)
         }
         menu_radio_codec_helper_8004158C(pActor, pOt, pPad);
     }
+#else
+    TEMPORARY_VR_MATCHING_PLACEHOLDER(0, 3, 4, 3);
+#endif
 }
 
 void menu_radio_init_80042700(Actor_MenuMan *pMenu)
@@ -2112,6 +2151,7 @@ extern SPRT gRadioStringSprt_800BD9F0;
 
 void menu_set_string2_80043138()
 {
+#ifndef VR_EXE
     PANEL_TEXTURE pPanelTex;
     RECT          rect;
 
@@ -2135,6 +2175,9 @@ void menu_set_string2_80043138()
     gRadioStringSprt_800BD9F0.h = 6;
     setSprt(&gRadioStringSprt_800BD9F0);
     setClut(&gRadioStringSprt_800BD9F0, rect.x, rect.y);
+#else
+    TEMPORARY_VR_MATCHING_PLACEHOLDER(0, 0, 5, 5);
+#endif
 }
 
 void menu_number_draw_string2_80043220(MenuPrim *pGlue, TextConfig *pTextConfig, const char *str)

--- a/src/Menu/radiofacedraw.c
+++ b/src/Menu/radiofacedraw.c
@@ -23,6 +23,7 @@ extern menu_0x14 stru_800BDA48[ 2 ];
 
 void sub_80048124()
 {
+#ifndef VR_EXE
     PANEL_TEXTURE pPanelTex;
     RECT          rect;
 
@@ -36,6 +37,9 @@ void sub_80048124()
 
     LoadImage(&rect, pPanelTex.field_4_word_ptr_pixels);
     dword_800ABB3C = (rect.y << 6) | (rect.x >> 4 & 0x3f);
+#else
+    TEMPORARY_VR_MATCHING_PLACEHOLDER(0, 0, 3, 8);
+#endif
 }
 
 void radio_draw_face_frame_800481CC(MenuPrim *pGlue, int x, int y, int w, int h)

--- a/src/Menu/radiotex.c
+++ b/src/Menu/radiotex.c
@@ -8,8 +8,13 @@ RECT        rect_800AB6C8;
 extern RECT rect_800AB6D0;
 RECT        rect_800AB6D0;
 
+#ifdef VR_EXE
+char SECTION(".rdata") strin3[] = "NO MEMORY FOR SAVE TEX\n";
+#endif
+
 void sub_800469F0(menu_chara_struct *pStru)
 {
+#ifndef VR_EXE
     int    offsetImage2;
     int    totalSize;
     short *pSaveText;
@@ -28,10 +33,14 @@ void sub_800469F0(menu_chara_struct *pStru)
     pSaveTextCopy = (char *)pStru->field_2C_pSaveText;
     StoreImage(&rect_800AB6C8, (u_long *)pSaveTextCopy);
     StoreImage(&rect_800AB6D0, (u_long *)(pSaveTextCopy + offsetImage2));
+#else
+    TEMPORARY_VR_MATCHING_PLACEHOLDER(0, 0, 3, 8);
+#endif
 }
 
 void menu_radio_codec_helper_helper7_helper_80046A98(menu_chara_struct *pStru)
 {
+#ifndef VR_EXE
     char *pSaveText;
     int   imageSize;
 
@@ -44,6 +53,9 @@ void menu_radio_codec_helper_helper7_helper_80046A98(menu_chara_struct *pStru)
 
     DrawSync(0);
     GV_FreeMemory_80015FD0(0, pStru->field_2C_pSaveText);
+#else
+    TEMPORARY_VR_MATCHING_PLACEHOLDER(0, 0, 2, 6);
+#endif
 }
 
 void sub_80046B10(face_anim_image *image, int idx)
@@ -60,6 +72,7 @@ void sub_80046B10(face_anim_image *image, int idx)
 
 void menu_radio_load_palette_80046B74(void *image, int idx)
 {
+#ifndef VR_EXE
     RECT v3;
 
     v3 = rect_800AB6C8;
@@ -67,10 +80,14 @@ void menu_radio_load_palette_80046B74(void *image, int idx)
     v3.y += idx;
 
     LoadImage(&v3, image);
+#else
+    TEMPORARY_VR_MATCHING_PLACEHOLDER(0, 0, 2, 2);
+#endif
 }
 
 void sub_80046BD8(int off)
 {
+#ifndef VR_EXE
     RECT rect;
 
     rect = rect_800AB6C8;
@@ -83,4 +100,7 @@ void sub_80046BD8(int off)
     rect.w = 32;
     rect.h = 96;
     MoveImage(&rect, rect_800AB6D0.x + off * 32, rect_800AB6D0.y);
+#else
+    TEMPORARY_VR_MATCHING_PLACEHOLDER(0, 0, 4, 3);
+#endif
 }

--- a/src/chara/snake/sna_init.c
+++ b/src/chara/snake/sna_init.c
@@ -319,8 +319,9 @@ GV_PAD GV_PadData_8009F0C4 = {0, 0, 0, 0, -1, 0, 0, 0, 0, 0};
 #define DispEmpty( pActor ) (pActor->field_9A0 = 4)
 #define SE_KARASHT          4
 
-void sub_8004EB74(Actor_SnaInit *pActor)
+void sub_8004EB74(Actor_SnaInit *pActor) // different in VR
 {
+#ifndef VR_EXE
     if (GM_Camera_800B77E8.field_22 == 0)
     {
         if (pActor->field_9B0_pad_ptr->dir == (short)-1)
@@ -343,15 +344,18 @@ void sub_8004EB74(Actor_SnaInit *pActor)
     }
 
     sd_set_cli_800887EC(0x1ffff20, 0);
+#else
+    TEMPORARY_VR_MATCHING_PLACEHOLDER(0, 0, 3, 1);
+#endif
 }
 
-void sna_8004EC00(Actor_SnaInit *pActor)
+void sna_8004EC00(Actor_SnaInit *pActor) // different in VR
 {
+#ifndef VR_EXE
     if (GM_Camera_800B77E8.field_22 == 1)
     {
         pActor->field_A20 = 6;
     }
-
     GM_Camera_800B77E8.field_22 = 0;
     pActor->field_A56 = 0;
 
@@ -365,10 +369,14 @@ void sna_8004EC00(Actor_SnaInit *pActor)
 
     sna_clear_flags2_8004E344(pActor, (SNA_FLAG2_UNK5 | SNA_FLAG2_UNK6));
     GM_ClearPlayerStatusFlag_8004E2D4(PLAYER_UNK400);
+#else
+    TEMPORARY_VR_MATCHING_PLACEHOLDER(0, 0, 2, 7);
+#endif
 }
 
-void sna_8004EC8C(Actor_SnaInit *pActor)
+void sna_8004EC8C(Actor_SnaInit *pActor) // different in VR
 {
+#ifndef VR_EXE
     ushort v2; // $v1
 
     sna_set_flags1_8004E2F4(pActor, SNA_FLAG1_UNK12);
@@ -382,10 +390,14 @@ void sna_8004EC8C(Actor_SnaInit *pActor)
     sd_set_cli_800887EC(0x1FFFF20, 0);
     sna_set_flags2_8004E330(pActor, SNA_FLAG2_UNK5);
     GM_ClearPlayerStatusFlag_8004E2D4(PLAYER_FIRST_PERSON);
+#else
+    TEMPORARY_VR_MATCHING_PLACEHOLDER(0, 0, 2, 4);
+#endif
 }
 
-void sub_8004ED08(Actor_SnaInit *pActor)
+void sub_8004ED08(Actor_SnaInit *pActor) // different in VR
 {
+#ifndef VR_EXE
     sna_clear_flags1_8004E308(pActor, SNA_FLAG1_UNK12);
     pActor->field_A28 = 0x1c2;
     GM_Camera_800B77E8.field_22 = 0; // weapon related?
@@ -393,6 +405,9 @@ void sub_8004ED08(Actor_SnaInit *pActor)
     sna_8004EB14(pActor);
     sd_set_cli_800887EC(0x1ffff21, 0);
     sna_clear_flags2_8004E344(pActor, (SNA_FLAG2_UNK5 | SNA_FLAG2_UNK6));
+#else
+    TEMPORARY_VR_MATCHING_PLACEHOLDER(0, 0, 2, 0);
+#endif
 }
 
 void sna_act_helper2_helper3_8004ED6C(Actor_SnaInit *pActor)
@@ -541,8 +556,9 @@ void sna_8004F034(Actor_SnaInit *pActor, unsigned int bits)
     }
 }
 
-void sna_act_helper2_helper4_8004F090(Actor_SnaInit *pActor, int param_2)
+void sna_act_helper2_helper4_8004F090(Actor_SnaInit *pActor, int param_2) // different in VR
 {
+#ifndef VR_EXE
     int    iVar1;
     MATRIX mtx;
 
@@ -570,10 +586,14 @@ void sna_act_helper2_helper4_8004F090(Actor_SnaInit *pActor, int param_2)
     {
         NewBlood_80072728(&mtx, iVar1);
     }
+#else
+    TEMPORARY_VR_MATCHING_PLACEHOLDER(0, 0, 4, 3);
+#endif
 }
 
-void sub_8004F14C(Actor_SnaInit *param_1)
+void sub_8004F14C(Actor_SnaInit *param_1) // different in VR
 {
+#ifndef VR_EXE
     param_1->field_91C_weapon_idx = WEAPON_NONE;
     GM_CurrentWeaponId = WEAPON_NONE;
 
@@ -602,10 +622,14 @@ void sub_8004F14C(Actor_SnaInit *param_1)
     {
         sna_8004EC00(param_1);
     }
+#else
+    TEMPORARY_VR_MATCHING_PLACEHOLDER(0, 0, 4, 1);
+#endif
 }
 
-void sub_8004F204(Actor_SnaInit *param_1)
+void sub_8004F204(Actor_SnaInit *param_1) // different in VR
 {
+#ifndef VR_EXE
     if (param_1->field_9A4_item_actor != 0)
     {
         GV_DestroyActorQuick_80015164(param_1->field_9A4_item_actor);
@@ -629,6 +653,9 @@ void sub_8004F204(Actor_SnaInit *param_1)
     }
 
     GM_ClearPlayerStatusFlag_8004E2D4(PLAYER_PREVENT_WEAPON_SWITCH | PLAYER_UNK1000);
+#else
+    TEMPORARY_VR_MATCHING_PLACEHOLDER(0, 0, 3, 4);
+#endif
 }
 
 void sna_set_invuln_8004F2A0(Actor_SnaInit *pActor, char invuln_frames)
@@ -645,8 +672,9 @@ void sna_clear_invuln_8004F2EC(Actor_SnaInit *snake)
     snake->field_89C_pTarget->class |= TARGET_FLAG;
 }
 
-void sub_8004F338(Actor_SnaInit *param_1)
+void sub_8004F338(Actor_SnaInit *param_1) // different in VR
 {
+#ifndef VR_EXE
     int iVar2;
 
     iVar2 = GM_CheckPlayerStatusFlag_8004E29C(PLAYER_FIRST_PERSON_DUCT);
@@ -687,10 +715,14 @@ void sub_8004F338(Actor_SnaInit *param_1)
     param_1->field_894_flags1 &= (SNA_FLAG1_UNK20 | SNA_FLAG1_UNK28 | SNA_FLAG1_UNK29);
     param_1->field_20_ctrl.field_55_skip_flag &= ~CTRL_BOTH_CHECK;
     sna_clear_flags2_8004E344(param_1, SNA_FLAG2_UNK9);
+#else
+    TEMPORARY_VR_MATCHING_PLACEHOLDER(0, 0, 6, 4);
+#endif
 }
 
-void sub_8004F454(Actor_SnaInit *pActor)
+void sub_8004F454(Actor_SnaInit *pActor) // different in VR
 {
+#ifndef VR_EXE
     int i;
 
     GM_ClearPlayerStatusFlag_8004E2D4(PLAYER_MOVING | PLAYER_PREVENT_FIRST_PERSON |
@@ -715,6 +747,9 @@ void sub_8004F454(Actor_SnaInit *pActor)
 
     pActor->field_20_ctrl.field_55_skip_flag &= ~CTRL_BOTH_CHECK;
     sna_clear_flags2_8004E344(pActor, SNA_FLAG2_UNK9);
+#else
+    TEMPORARY_VR_MATCHING_PLACEHOLDER(0, 0, 5, 5);
+#endif
 }
 
 int sna_8004F544(Actor_SnaInit *pActor, SVECTOR param_2, int a3, int a4, int a5)
@@ -809,8 +844,9 @@ static inline int sna_update_life_helper_8004F6E8(int health, int item)
     return health;
 }
 
-void UpdateLife_8004F6E8(Actor_SnaInit *pActor)
+void UpdateLife_8004F6E8(Actor_SnaInit *pActor) // different in VR
 {
+#ifndef VR_EXE
     int health;
 
     if (sna_check_flags1_8004E31C(pActor, SNA_FLAG1_UNK23))
@@ -857,6 +893,9 @@ void UpdateLife_8004F6E8(Actor_SnaInit *pActor)
     GM_SnakeCurrentHealth = health;
 
     sna_set_flags1_8004E2F4(pActor, SNA_FLAG1_UNK25);
+#else
+    TEMPORARY_VR_MATCHING_PLACEHOLDER(0, 1, 4, 6);
+#endif
 }
 
 void sna_8004F8E4(Actor_SnaInit *pActor, int a2)

--- a/src/chara/snake/snake.c
+++ b/src/chara/snake/snake.c
@@ -104,6 +104,7 @@ void sna_clear_flags2_8004E344(Actor_SnaInit *snake, SnaFlag2 flags)
 
 unsigned int sna_sub_8004E358(Actor_SnaInit *snake, SnaFlag2 param_2)
 {
+#ifndef VR_EXE
     unsigned int result = 0;
 
     if (GM_UnkFlagBE != 0)
@@ -112,10 +113,14 @@ unsigned int sna_sub_8004E358(Actor_SnaInit *snake, SnaFlag2 param_2)
     }
 
     return result;
+#else
+    TEMPORARY_VR_MATCHING_PLACEHOLDER(0, 0, 0, 3);
+#endif
 }
 
 void CheckSnakeDead_8004E384(Actor_SnaInit *snake)
 {
+#ifndef VR_EXE
     if ((GM_SnakeCurrentHealth == 0) || (GM_GameOverTimer_800AB3D4 != 0))
     {
         snake->field_20_ctrl.field_55_skip_flag |= CTRL_SKIP_TRAP;
@@ -128,10 +133,14 @@ void CheckSnakeDead_8004E384(Actor_SnaInit *snake)
             sna_set_flags1_8004E2F4(snake, (SNA_FLAG1_UNK5 | SNA_FLAG1_UNK6));
         }
     }
+#else
+    TEMPORARY_VR_MATCHING_PLACEHOLDER(0, 0, 3, 6);
+#endif
 }
 
 void sna_sub_8004E41C(Actor_SnaInit *snake, unsigned short flags)
 {
+#ifndef VR_EXE
     TARGET *target = snake->field_8E8_pTarget;
 
     if (target != NULL)
@@ -141,6 +150,9 @@ void sna_sub_8004E41C(Actor_SnaInit *snake, unsigned short flags)
         snake->field_A54.choke_count = 0;
         snake->field_89C_pTarget->field_10_size.vx = 300;
     }
+#else
+    TEMPORARY_VR_MATCHING_PLACEHOLDER(0, 0, 1, 3);
+#endif
 }
 
 // ... categorize move/turn direction by angle?
@@ -148,6 +160,7 @@ void sna_sub_8004E41C(Actor_SnaInit *snake, unsigned short flags)
 // param_2: gSnaMoveDir_800ABBA4
 int sub_8004E458(short param_1, int param_2)
 {
+#ifndef VR_EXE
     short uVar2;
 
     if (param_2 < 0)
@@ -183,6 +196,9 @@ int sub_8004E458(short param_1, int param_2)
 
         return 2;
     }
+#else
+    TEMPORARY_VR_MATCHING_PLACEHOLDER(0, 0, 0, 9);
+#endif
 }
 
 int sub_8004E4C0(Actor_SnaInit *pActor, int param_2)
@@ -237,6 +253,7 @@ void sub_8004E588(HZD_HDL *param_1, SVECTOR *param_2, int *param_3)
 
 int sub_8004E5E8(Actor_SnaInit *pActor, int flag)
 {
+#ifndef VR_EXE
     int     i;
     SVECTOR vec;
     int     unk1[2];
@@ -281,6 +298,9 @@ int sub_8004E5E8(Actor_SnaInit *pActor, int flag)
     }
 
     return 2;
+#else
+    TEMPORARY_VR_MATCHING_PLACEHOLDER(0, 0, 7, 4);
+#endif
 }
 
 int sna_8004E71C(int a1, HZD_HDL *pHzd, SVECTOR *pVec, int a4)

--- a/src/libdg/display.c
+++ b/src/libdg/display.c
@@ -69,8 +69,9 @@ void DG_RenderPipeline_Init_8001715C(void)
     DG_RenderPipeline_80018028(1);
 }
 
-void DG_80017194()
+void DG_80017194() // different in VR
 {
+#ifndef VR_EXE
     int activeBuffer = GV_Clock_800AB920;
     if ((GV_PauseLevel_800AB928 & 8) != 0 || DG_UnDrawFrameCount_800AB380 > 0)
     {
@@ -104,6 +105,9 @@ void DG_80017194()
     menu_ResetSystem_80038A88();
     DG_ClearChanlSystem_80017E9C(activeBuffer);
     DG_ClearTmpLight_8001A0E4();
+#else
+    TEMPORARY_VR_MATCHING_PLACEHOLDER(0, 0, 6, 6);
+#endif
 }
 
 void DG_RenderPipeline_800172A8(void)

--- a/src/libdg/palette.c
+++ b/src/libdg/palette.c
@@ -8,13 +8,21 @@ RECT SECTION(".sdata") rect_800AB3A8;
 extern RECT rect_800AB3B0;
 RECT SECTION(".sdata") rect_800AB3B0;
 
-void DG_StorePalette_8001FC28(void)
+void DG_StorePalette_8001FC28(void) // different in VR
 {
+#ifndef VR_EXE
     MoveImage(&rect_800AB3A8, rect_800AB3B0.x, rect_800AB3B0.y);
+#else
+    TEMPORARY_VR_MATCHING_PLACEHOLDER(0, 0, 0, 9);
+#endif
 }
 
-void DG_ReloadPalette_8001FC58(void)
+void DG_ReloadPalette_8001FC58(void) // different in VR
 {
+#ifndef VR_EXE
     MoveImage(&rect_800AB3B0, rect_800AB3A8.x, rect_800AB3A8.y);
+#else
+    TEMPORARY_VR_MATCHING_PLACEHOLDER(0, 0, 0, 9);
+#endif
 }
 

--- a/src/libdg/screen.c
+++ b/src/libdg/screen.c
@@ -289,6 +289,12 @@ void sub_8001C460(DG_OBJS *objs, int n_obj)
     }
 }
 
+#ifdef VR_EXE
+void new_vr_screen_func() {
+    TEMPORARY_VR_MATCHING_PLACEHOLDER(0, 1, 0, 5);
+}
+#endif
+
 // set obj world accoring to parent?
 void sub_8001C5CC(DG_OBJS *objs, int n_obj)
 {
@@ -425,7 +431,7 @@ void sub_8001C708( DG_OBJS* objs, int n_obj )
     }
 }
 
-void DG_8001CDB8(DG_OBJS *pObjs)
+void DG_8001CDB8(DG_OBJS *pObjs) // different in VR
 {
     MATRIX *root = pObjs->root;
     int     n_models = pObjs->n_models;
@@ -452,6 +458,9 @@ void DG_8001CDB8(DG_OBJS *pObjs)
         }
         sub_8001C460(pObjs, n_models);
     }
+#ifdef VR_EXE
+    TEMPORARY_VR_MATCHING_PLACEHOLDER(0, 0, 0, 7);
+#endif
 }
 
 void DG_Screen_Chanl_8001CEE0(DG_CHNL *pOt, int idx)

--- a/src/libgcl/command.c
+++ b/src/libgcl/command.c
@@ -211,12 +211,20 @@ int GCL_ExecBlock_80020118(unsigned char *pScript, GCL_ARGS *pArgs)
 // extern const char aNotScriptData[];
 extern GCL_ARGS gcl_null_args_800AB3BC;
 
-void GCL_ExecScript_80020228()
+#ifdef VR_EXE
+const char constant[] = "NOT SCRIPT DATA !!\n";
+#endif
+
+void GCL_ExecScript_80020228() // different in VR
 {
+#ifndef VR_EXE
     unsigned char *pMainProc = gGCL_fileData_800B3C18.field_8_pMainProc;
     if (*pMainProc != 0x40)
     {
         printf("NOT SCRIPT DATA !!\n");
     }
     GCL_ExecBlock_80020118(pMainProc + 3, &gcl_null_args_800AB3BC);
+#else
+    TEMPORARY_VR_MATCHING_PLACEHOLDER(0, 0, 1, 6);
+#endif
 }

--- a/src/libgv/pad.c
+++ b/src/libgv/pad.c
@@ -35,6 +35,13 @@ extern int   DG_UnDrawFrameCount_800AB380;
 extern int   GM_GameStatus_800AB3CC;
 extern int   GV_Time_800AB330;
 
+#ifdef VR_EXE
+int some_new_vr_func()
+{
+    TEMPORARY_VR_MATCHING_PLACEHOLDER(0, 0, 1, 3);
+}
+#endif
+
 int GV_UpdatePadSystem_helper_helper_800166AC(int a0, int a1, int a2)
 {
     int v1, i;
@@ -136,7 +143,7 @@ void GV_InitPadSystem_800167C8(void)
 }
 
 void GV_UpdatePadSystem_8001682C(void)
-{
+{ // this function is different in vr
     int           chan, prev;
     unsigned int  t0, t1, t2, t3, t4, t5;
     short        *table;
@@ -355,6 +362,9 @@ void GV_UpdatePadSystem_8001682C(void)
         pad++;
         button = (button >> 16) & 0xFFFF;
     }
+#ifdef VR_EXE
+    TEMPORARY_VR_MATCHING_PLACEHOLDER(0, 0, 1, 4);
+#endif
 }
 
 void GV_OriginPadSystem_80016C78(int org)

--- a/src/linker.h
+++ b/src/linker.h
@@ -19,4 +19,24 @@
 #define STATIC_ASSERT_SIZE(struct, size) STATIC_ASSERT(sizeof(struct) == size, wrong_size, __LINE__)
 #endif
 
+#define REP0(X)
+#define REP1(X) X
+#define REP2(X) REP1(X) X
+#define REP3(X) REP2(X) X
+#define REP4(X) REP3(X) X
+#define REP5(X) REP4(X) X
+#define REP6(X) REP5(X) X
+#define REP7(X) REP6(X) X
+#define REP8(X) REP7(X) X
+#define REP9(X) REP8(X) X
+#define REP10(X) REP9(X) X
+
+#define REP(THOUSANDS,HUNDREDS,TENS,ONES,X) \
+  REP##THOUSANDS(REP10(REP10(REP10(X)))) \
+  REP##HUNDREDS(REP10(REP10(X))) \
+  REP##TENS(REP10(X)) \
+  REP##ONES(X)
+
+#define TEMPORARY_VR_MATCHING_PLACEHOLDER(THOUSANDS,HUNDREDS,TENS,ONES) REP(THOUSANDS,HUNDREDS,TENS,ONES, asm("nop");)
+
 #endif // LINKER_H_


### PR DESCRIPTION
A substantial portion now "aligns":

VR exe aligns up to ~0x40270 (first ~262 KBs - that doesn't mean that the all 262 KB are equal, but that the differences are mostly relocations, not some shifts (bytes added/removed))

SLPM_862.49 reversed bytes: 294,744 / 632,832 | 46.58%