### PR TITLE
Use renamed psylink_overlay_fopen_mod, small improvements

### DIFF
--- a/build/build.py
+++ b/build/build.py
@@ -152,7 +152,7 @@ ninja.variable("psyq_aspsx_2_81_exe", prefix("wibo", "$psyq_path/ASPSX/2.81/ASPS
 ninja.variable("psyq_psylink_exe", prefix("wibo", "$psyq_path/psyq_4.4/bin/psylink.exe"))
 ninja.newline()
 
-ninja.variable("psyq_psylink_overlay_fopen_patch_exe", prefix("wibo", "$psyq_path/psyq_4.4/bin/psylink_overlay_fopen_patch.exe"))
+ninja.variable("psyq_psylink_overlay_fopen_mod_exe", prefix("wibo", "$psyq_path/psyq_4.4/bin/psylink_overlay_fopen_mod.exe"))
 ninja.newline()
 
 ninja.variable("src_dir", "../src")
@@ -218,7 +218,7 @@ ninja.newline()
 ninja.rule("create_dummy_file_overlays", f"{sys.executable} $src_dir/../build/create_dummy_file.py $src_dir/../{args.obj_directory}/$overlay_bin $src_dir/../{args.obj_directory}/$overlay_bss_bin", "Create dummy files $overlay_bin, $overlay_bss_bin")
 ninja.newline()
 
-ninja.rule("psylink_overlay_fopen_patch", f"$psyq_psylink_overlay_fopen_patch_exe /l {psqy_lib} /c /n 4000 /q /gp .sdata /m \"@$src_dir/../{args.obj_directory}/linker_command_file$suffix.txt\",$src_dir/../{args.obj_directory}/_mgsi$suffix.cpe,$src_dir/../{args.obj_directory}/asm$suffix.sym,$src_dir/../{args.obj_directory}/asm$suffix.map", "Link (uninitialized) $out")
+ninja.rule("psylink_overlay_fopen_mod", f"$psyq_psylink_overlay_fopen_mod_exe /l {psqy_lib} /c /n 4000 /q /gp .sdata /m \"@$src_dir/../{args.obj_directory}/linker_command_file$suffix.txt\",$src_dir/../{args.obj_directory}/_mgsi$suffix.cpe,$src_dir/../{args.obj_directory}/asm$suffix.sym,$src_dir/../{args.obj_directory}/asm$suffix.map", "Link (uninitialized) $out")
 ninja.newline()
 
 ninja.rule("uninitializer", f"{sys.executable} $src_dir/../build/uninitializer.py inject $in $out", "Uninitializer $in -> $out")
@@ -432,7 +432,7 @@ def gen_build_target(targetName):
         ninja.newline()
 
         rhsOverlayFile = f"../{args.obj_directory}/{overlay}_rhs.bin"
-        ninja.build(rhsOverlayFile, "psylink_overlay_fopen_patch", implicit=linkerDeps + [linkerCommandFile, dummyFile], variables={"suffix": f"_{overlay}_rhs"})
+        ninja.build(rhsOverlayFile, "psylink_overlay_fopen_mod", implicit=linkerDeps + [linkerCommandFile, dummyFile], variables={"suffix": f"_{overlay}_rhs"})
         ninja.newline()
 
         overlayFile = f"../{args.obj_directory}/{overlay}.bin"

--- a/build/decompme_asm.py
+++ b/build/decompme_asm.py
@@ -44,15 +44,9 @@ def get_map(path):
     # Overlay?
     path = os.path.normpath(path).split(os.path.sep)
     overlay_name = next((t for s, t in zip(path, path[1:]) if s == "overlays"), None)
-    overlay_map = os.path.join(root_dir, f"asm_{overlay_name}.map")
+    overlay_map = os.path.join(root_dir, f"asm_{overlay_name}_lhs.map")
     if overlay_name and os.path.exists(overlay_map):
         map_file = overlay_map
-
-    # VR?
-    # TODO: remove once VR is matched
-    vr_dir = os.path.realpath(os.path.join(os.path.dirname(__file__), '../obj_vr'))
-    if ("asm", "chara", "snake_vr") in zip(path, path[1:], path[2:]):
-        map_file = os.path.join(vr_dir, f"asm.map")
 
     ret = {}
     with open(map_file) as f:

--- a/build/uninitializer.py
+++ b/build/uninitializer.py
@@ -91,8 +91,9 @@ def inject(lhs, rhs, uninitialized, out):
 
     uninitialized_cur_idx = 0
 
-    assert len(lhs) < DUMMY_FILE_SIZE
-    assert len(lhs) < len(rhs)
+    assert len(rhs) == DUMMY_FILE_SIZE, f"RHS overlay should be {DUMMY_FILE_SIZE} bytes large, but it's {len(rhs)} bytes large"
+    assert len(lhs) < DUMMY_FILE_SIZE, f"LHS overlay is too large ({len(lhs)} bytes large)"
+    assert len(lhs) < len(rhs), f"LHS overlay is too large ({len(lhs)} bytes large)"
 
     out_arr = bytearray(lhs)
 
@@ -100,7 +101,7 @@ def inject(lhs, rhs, uninitialized, out):
         if lb == rb:
             continue
 
-        assert lb == 0 and rb == 0x9e
+        assert lb == 0 and rb == 0x9e, f"LHS and RHS differ in more than uninitialized memory at offset {i}, {lb:X} != {rb:X}"
 
         # Uninitialized memory!
         out_arr[i] = uninitialized[uninitialized_cur_idx]
@@ -113,9 +114,10 @@ def extract(lhs, rhs, target, uninitialized_out):
     rhs = open(rhs, 'rb').read()
     target = open(target, 'rb').read()
 
-    assert len(lhs) < DUMMY_FILE_SIZE
-    assert len(lhs) < len(rhs)
-    assert len(lhs) == len(target)
+    assert len(rhs) == DUMMY_FILE_SIZE, f"RHS overlay should be {DUMMY_FILE_SIZE} bytes large, but it's {len(rhs)} bytes large"
+    assert len(lhs) < DUMMY_FILE_SIZE, f"LHS overlay is too large ({len(lhs)} bytes large)"
+    assert len(lhs) < len(rhs), f"LHS overlay is too large ({len(lhs)} bytes large)"
+    assert len(lhs) == len(target), f"LHS overlay should the same size as target. len(lhs) = {len(lhs)}, len(target) = {len(target)}"
 
     uninitialized_out_arr = []
     nonzero_uninitialized = 0
@@ -124,7 +126,7 @@ def extract(lhs, rhs, target, uninitialized_out):
         if lb == rb and rb == tb:
             continue
 
-        assert lb == 0 and rb == 0x9e
+        assert lb == 0 and rb == 0x9e, f"LHS and RHS differ in more than uninitialized memory at offset {i}, {lb:X} != {rb:X}"
 
         # Uninitialized memory!
         uninitialized_out_arr.append(tb)

--- a/src/overlays/s16b/unknown.c
+++ b/src/overlays/s16b/unknown.c
@@ -1,7 +1,7 @@
 #include "libdg/libdg.h"
 #include "libgcl/libgcl.h"
 
-static int THING_msg_result[2];
+int SECTION("overlay.bss") THING_msg_result[2];
 
 int THING_Gcl_GetIntDefault(char param, int def)
 {


### PR DESCRIPTION
The executable was renamed, because otherwise Windows required admin privileges to run it. As per https://stackoverflow.com/a/11573516:

>  If the file contains the words "install", "setup", "update" or "patch", [Windows will ask for administrator privileges to run]