### PR TITLE
Cleanups & fix for SetPriority (undocumented libgpu.h API)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+end_of_line = lf
+max_line_length = off
+
+[*.{c,h}]
+tab_width       = 4
+indent_size     = tab
+indent_style    = space
+
+[*.{asm,s}]
+tab_width       = 8
+indent_size     = tab
+indent_style    = tab

--- a/asm/SAFECHK.s
+++ b/asm/SAFECHK.s
@@ -1,707 +1,711 @@
-    opt	c+, at+, e+, n-
+	opt	c+, at+, e+, n-
 
-    ; asmpsx has a conflicting macro named strlen
-    disable strlen
+	; asmpsx has a conflicting macro named strlen
+	disable strlen
 
-    section .rdata
-    section .text
-    section .data
-    section .sdata
-    section .sbss
-    section .bss
+	section .rdata
+	section .text
+	section .data
+	section .sdata
+	section .sbss
+	section .bss
 
-    xdef	SafetyCheck
+	xref	VSync
+	xref	ResetGraph
+	xref	StopCallback
+	xref	SetDefDrawEnv
+	xref	SetDefDispEnv
+	xref	SetDrawEnv
+	xref	DrawPrim
+	xref	PutDispEnv
+	xref	SetDispMask
+	xref	exit
+	xref	strlen
+	xref	Krom2RawAdd
 
-    xref	VSync
-    xref 	ResetGraph
-    xref 	StopCallback
-    xref 	SetDefDrawEnv
-    xref 	SetDefDispEnv
-    xref 	SetDrawEnv
-    xref 	DrawPrim
-    xref 	PutDispEnv
-    xref 	SetDispMask
-    xref 	exit
-    xref 	strlen
-    xref 	Krom2RawAdd
+	section .text
 
-    section .text
+	xdef	SafetyCheck
 
+; extern int SafetyCheck( int minute, int second, int sector );
 SafetyCheck:
-    addiu	sp, sp, -0x30
-    sw		s2, 0x20(sp)
-    move	s2, a0
-    sw		s3, 0x24(sp)
-    move 	s3, a1
-    sw 		s4, 0x28(sp)
-    move 	s4, a2
-    sw 		s0, 0x18(sp)
-    move 	s0, zero
-    addiu 	v0, zero, 0x20
-    sw 		ra, 0x2c(sp)
-    sw 		s1, 0x1c(sp)
-    sb 		v0, safety_check_params
-    jal 	SafetyCheck1
-    addiu 	a0, zero, 5
-    bltz 	v0, @lab_164
-    nop
-    jal 	SafetyCheck1
-    move 	a0, zero
-    bltz 	v0, @lab_164
-    nop
-    lbu 	v1, safety_check_results
-    nop
-    andi 	v0, v1, 0xf0
-    bnez 	v0, @lab_164
-    andi 	v0, v1, 2
-    bnez 	v0, @lab_88
-    addiu 	a0, zero, 2
-    jal 	SafetyCheck1
-    addiu 	a0, zero, 1
-    bltz 	v0, @lab_164
-    addiu 	a0, zero, 2
+	addiu	sp, sp, -0x30
+	sw	s2, 0x20(sp)
+	move	s2, a0
+	sw	s3, 0x24(sp)
+	move	s3, a1
+	sw	s4, 0x28(sp)
+	move	s4, a2
+	sw	s0, 0x18(sp)
+	move	s0, zero
+	addiu	v0, zero, 0x20
+	sw	ra, 0x2c(sp)
+	sw	s1, 0x1c(sp)
+	sb	v0, safechk_params
+	jal	SafetyCheck1
+	addiu	a0, zero, 5
+	bltz	v0, @lab_164
+	nop
+	jal	SafetyCheck1
+	move	a0, zero
+	bltz	v0, @lab_164
+	nop
+	lbu	v1, safechk_results
+	nop
+	andi	v0, v1, 0xf0
+	bnez	v0, @lab_164
+	andi	v0, v1, 2
+	bnez	v0, @lab_88
+	addiu	a0, zero, 2
+	jal	SafetyCheck1
+	addiu	a0, zero, 1
+	bltz	v0, @lab_164
+	addiu	a0, zero, 2
 
 @lab_88:
-    la 		s1, safety_check_params
-    sb 		s2, 0(s1)
-    sb 		s3, 1(s1)
-    jal 	SafetyCheck1
-    sb 		s4, 2(s1)
-    bltz 	v0, @lab_164
-    addiu 	v0, zero, 1
-    sb 		v0, 0(s1)
-    jal 	SafetyCheck1
-    addiu 	a0, zero, 4
-    bltz 	v0, @lab_164
-    nop
-    jal 	VSync
-    addiu 	a0, zero, 3
-    jal 	SafetyCheck1
-    addiu 	a0, zero, 3
-    bltz 	v0, @lab_164
-    nop
-    jal 	SafetyCheck1
-    addiu 	a0, zero, 6
-    bltz	v0, @lab_164
-    nop
-    jal		SafetyCheck1
-    addiu	a0, zero, 7
-    bltz	v0, @lab_164
-    addiu	v0, zero, 4
-    sb		v0, 0(s1)
-    jal		SafetyCheck1
-    addiu	a0, zero, 8
-    bltz	v0, @lab_164
-    nop
-    jal		VSync
-    addiu	a0, zero, 0xc8
-    addiu	v0, zero, 5
-    sb		v0, 0(s1)
-    jal 	SafetyCheck1
-    addiu 	a0, zero, 8
-    bltz 	v0, @lab_164
-    nop
-    la		s1, (safety_check_results+1)
-    lbu		v0, 0(s1)
-    nop
-    beqz 	v0, @lab_174
-    nop
-    jal 	SafetyCheck1
-    move	a0, zero
-    bltz	v0, @lab_164
-    nop
-    lbu 	v0, -1(s1)
-    nop
-    andi 	v0, v0, 0x10
-    beqz 	v0, @lab_16c
-    nop
+	la	s1, safechk_params
+	sb	s2, 0(s1)
+	sb	s3, 1(s1)
+	jal	SafetyCheck1
+	sb	s4, 2(s1)
+	bltz	v0, @lab_164
+	addiu	v0, zero, 1
+	sb	v0, 0(s1)
+	jal	SafetyCheck1
+	addiu	a0, zero, 4
+	bltz	v0, @lab_164
+	nop
+	jal	VSync
+	addiu	a0, zero, 3
+	jal	SafetyCheck1
+	addiu	a0, zero, 3
+	bltz	v0, @lab_164
+	nop
+	jal	SafetyCheck1
+	addiu	a0, zero, 6
+	bltz	v0, @lab_164
+	nop
+	jal	SafetyCheck1
+	addiu	a0, zero, 7
+	bltz	v0, @lab_164
+	addiu	v0, zero, 4
+	sb	v0, 0(s1)
+	jal	SafetyCheck1
+	addiu	a0, zero, 8
+	bltz	v0, @lab_164
+	nop
+	jal	VSync
+	addiu	a0, zero, 0xc8
+	addiu	v0, zero, 5
+	sb	v0, 0(s1)
+	jal	SafetyCheck1
+	addiu	a0, zero, 8
+	bltz	v0, @lab_164
+	nop
+	la	s1, (safechk_results+1)
+	lbu	v0, 0(s1)
+	nop
+	beqz	v0, @lab_174
+	nop
+	jal	SafetyCheck1
+	move	a0, zero
+	bltz	v0, @lab_164
+	nop
+	lbu	v0, -1(s1)
+	nop
+	andi	v0, v0, 0x10
+	beqz	v0, @lab_16c
+	nop
 
 @lab_164:
-    j 		@lab_174
-    addiu	s0, zero, -1
+	j	@lab_174
+	addiu	s0, zero, -1
 
 @lab_16c:
-    jal		SafetyCheck2
-    nop
+	jal	SafetyCheck2
+	nop
 
 @lab_174:
-    jal 	SafetyCheck1
-    addiu	a0, zero, 9
-    bgez	v0, @lab_18c
-    move	v0, s0
-    addiu	s0, zero, -1
-    move	v0, s0
+	jal	SafetyCheck1
+	addiu	a0, zero, 9
+	bgez	v0, @lab_18c
+	move	v0, s0
+	addiu	s0, zero, -1
+	move	v0, s0
 
 @lab_18c:
-    lw		ra, 0x2c(sp)
-    lw		s4, 0x28(sp)
-    lw		s3, 0x24(sp)
-    lw		s2, 0x20(sp)
-    lw		s1, 0x1c(sp)
-    lw		s0, 0x18(sp)
-    jr		ra
-    addiu	sp, sp, 0x30
+	lw	ra, 0x2c(sp)
+	lw	s4, 0x28(sp)
+	lw	s3, 0x24(sp)
+	lw	s2, 0x20(sp)
+	lw	s1, 0x1c(sp)
+	lw	s0, 0x18(sp)
+	jr	ra
+	addiu	sp, sp, 0x30
 
+; static int SafetyCheck1( int $a0 );
 SafetyCheck1:
-    move	t0, a0
-    move	a0, zero
-    move	a1, zero
-    lw		v1, safety_check_cdregs
-    addiu	v0, zero, 1
-    sb		v0, 0(v1)
-    lw		v1, safety_check_cdregs+12
-    addiu	v0, zero, 7
-    sb		v0, 0(v1)
+	move	t0, a0
+	move	a0, zero
+	move	a1, zero
+	lw	v1, safechk_cdregs
+	addiu	v0, zero, 1
+	sb	v0, 0(v1)
+	lw	v1, safechk_cdregs+12
+	addiu	v0, zero, 7
+	sb	v0, 0(v1)
 
 @lab_2c:
-    sw		a0, 0(a1)
-    addiu	a0, a0, 1
-    slti	v0, a0, 4
-    bnez	v0, @lab_2c
-    addiu	v0, zero, 1
-    lw		v1, safety_check_cdregs
-    nop
-    sb		v0, 0(v1)
-    lw		v1, safety_check_cdregs+8
-    addiu	v0, zero, 0x18
-    sb		v0, 0(v1)
-    lw		v0, safety_check_cdregs
-    sll		a0, t0, 2
-    sb		zero, 0(v0)
-    opt m-
-    lui		v0, safety_check_commands>>16
-    addu    v0, v0, a0
-    lbu		v0, (safety_check_commands&0xffff)+1(v0)
-    opt m+
-    nop
-    beqz	v0, @lab_c0
-    move	a1, zero
+	sw	a0, 0(a1)
+	addiu	a0, a0, 1
+	slti	v0, a0, 4
+	bnez	v0, @lab_2c
+	addiu	v0, zero, 1
+	lw	v1, safechk_cdregs
+	nop
+	sb	v0, 0(v1)
+	lw	v1, safechk_cdregs+8
+	addiu	v0, zero, 0x18
+	sb	v0, 0(v1)
+	lw	v0, safechk_cdregs
+	sll	a0, t0, 2
+	sb	zero, 0(v0)
+	opt m-
+	lui	v0, safechk_commands>>16
+	addu	v0, v0, a0
+	lbu	v0, (safechk_commands&0xffff)+1(v0)
+	opt m+
+	nop
+	beqz	v0, @lab_c0
+	move	a1, zero
 
 @lab_88:
-    lw		v0, safety_check_cdregs+8
-    opt m-
-    lui		v1, safety_check_params>>16
-    addu    v1, v1, a1
-    lbu		v1, safety_check_params&0xffff(v1)
-    nop
-    sb		v1, 0(v0)
-    lui		v0, safety_check_commands>>16
-    addu    v0, v0, a0
-    lbu		v0, (safety_check_commands&0xffff)+1(v0)
-    opt m+
-    addiu	a1, a1, 1
-    slt		v0, a1, v0
-    bnez	v0, @lab_88
-    nop
+	lw	v0, safechk_cdregs+8
+	opt m-
+	lui	v1, safechk_params>>16
+	addu	v1, v1, a1
+	lbu	v1, safechk_params&0xffff(v1)
+	nop
+	sb	v1, 0(v0)
+	lui	v0, safechk_commands>>16
+	addu	v0, v0, a0
+	lbu	v0, (safechk_commands&0xffff)+1(v0)
+	opt m+
+	addiu	a1, a1, 1
+	slt	v0, a1, v0
+	bnez	v0, @lab_88
+	nop
 
 @lab_c0:
-    lw		v0, safety_check_cdregs
-    sll		a0, t0, 2
-    sb		zero, 0(v0)
-    lw		v1, safety_check_cdregs+4
-    opt m-
-    lui		v0, safety_check_commands>>16
-    addu    v0, v0, a0
-    lbu		v0, safety_check_commands&0xffff(v0)
-    move	a1, zero
-    sb		v0, 0(v1)
-    lui		v0, safety_check_commands>>16
-    addu    v0, v0, a0
-    lbu		v0, (safety_check_commands&0xffff)+3(v0)
-    opt m+
-    nop
-    beqz	v0, @lab_194
-    move	a2, zero
-    addiu	a3, zero, 1
-    addiu	t2, zero, 7
-    move	t1, v0
+	lw	v0, safechk_cdregs
+	sll	a0, t0, 2
+	sb	zero, 0(v0)
+	lw	v1, safechk_cdregs+4
+	opt m-
+	lui	v0, safechk_commands>>16
+	addu	v0, v0, a0
+	lbu	v0, safechk_commands&0xffff(v0)
+	move	a1, zero
+	sb	v0, 0(v1)
+	lui	v0, safechk_commands>>16
+	addu	v0, v0, a0
+	lbu	v0, (safechk_commands&0xffff)+3(v0)
+	opt m+
+	nop
+	beqz	v0, @lab_194
+	move	a2, zero
+	addiu	a3, zero, 1
+	addiu	t2, zero, 7
+	move	t1, v0
 
 @lab_110:
-    lw		v0, safety_check_cdregs
-    nop
-    sb		a3, 0(v0)
-    lw		a0, safety_check_cdregs+12
-    nop
+	lw	v0, safechk_cdregs
+	nop
+	sb	a3, 0(v0)
+	lw	a0, safechk_cdregs+12
+	nop
 
 @lab_12c:
-    lbu		v1, 0(a0)
-    lbu		v0, 0(a0)
-    andi	v1, v1, 7
-    andi	v0, v0, 7
-    bne		v1, v0, @lab_12c
-    move	a1, v1
-    andi	v0, a1, 0xff
-    beqz	v0, @lab_188
-    nop
-    addu	a2, a2, v0
-    lw		v0, safety_check_cdregs
-    move	v1, zero
-    sb		a3, 0(v0)
-    lw		v0, safety_check_cdregs+12
-    move	a0, zero
-    sb		t2, 0(v0)
+	lbu	v1, 0(a0)
+	lbu	v0, 0(a0)
+	andi	v1, v1, 7
+	andi	v0, v0, 7
+	bne	v1, v0, @lab_12c
+	move	a1, v1
+	andi	v0, a1, 0xff
+	beqz	v0, @lab_188
+	nop
+	addu	a2, a2, v0
+	lw	v0, safechk_cdregs
+	move	v1, zero
+	sb	a3, 0(v0)
+	lw	v0, safechk_cdregs+12
+	move	a0, zero
+	sb	t2, 0(v0)
 
 @lab_174:
-    sw		v1, 0(a0)
-    addiu	v1, v1, 1
-    slti	v0, v1, 4
-    bnez	v0, @lab_174
-    nop
+	sw	v1, 0(a0)
+	addiu	v1, v1, 1
+	slti	v0, v1, 4
+	bnez	v0, @lab_174
+	nop
 
 @lab_188:
-    slt		v0, a2, t1
-    bnez	v0, @lab_110
-    nop
+	slt	v0, a2, t1
+	bnez	v0, @lab_110
+	nop
 
 @lab_194:
-    addiu	v0, zero, 5
-    bne		a1, v0, @lab_1a4
-    move	v1, zero
-    addiu	v1, zero, -1
+	addiu	v0, zero, 5
+	bne	a1, v0, @lab_1a4
+	move	v1, zero
+	addiu	v1, zero, -1
 
 @lab_1a4:
-    bgez 	v1, @lab_1b4
-    sll 	a0, t0, 2
-    j 		@lab_208
-    addiu 	v0, zero, -1
+	bgez	v1, @lab_1b4
+	sll	a0, t0, 2
+	j	@lab_208
+	addiu	v0, zero, -1
 
 @lab_1b4:
-    opt m-
-    lui		v0, safety_check_commands>>16
-    addu    v0, v0, a0
-    lbu		v0, (safety_check_commands&0xffff)+2(v0)
-    opt m+
-    nop
-    beqz	v0, @lab_204
-    move	a1, zero
+	opt m-
+	lui	v0, safechk_commands>>16
+	addu	v0, v0, a0
+	lbu	v0, (safechk_commands&0xffff)+2(v0)
+	opt m+
+	nop
+	beqz	v0, @lab_204
+	move	a1, zero
 
 @lab_1cc:
-    lw 		v0, safety_check_cdregs+4
-    nop
-    lbu		v0, 0(v0)
-    sb		v0, safety_check_results(a1)
-    opt	m-
-    lui		v0, safety_check_commands>>16
-    addu    v0, v0, a0
-    lbu		v0, (safety_check_commands&0xffff)+2(v0)
-    opt	m+
-    addiu	a1, a1, 1
-    slt		v0, a1, v0
-    bnez	v0, @lab_1cc
-    nop
+	lw	v0, safechk_cdregs+4
+	nop
+	lbu	v0, 0(v0)
+	sb	v0, safechk_results(a1)
+	opt	m-
+	lui	v0, safechk_commands>>16
+	addu	v0, v0, a0
+	lbu	v0, (safechk_commands&0xffff)+2(v0)
+	opt	m+
+	addiu	a1, a1, 1
+	slt	v0, a1, v0
+	bnez	v0, @lab_1cc
+	nop
 
 @lab_204:
-    move	v0, zero
+	move	v0, zero
 
 @lab_208:
-    lw		a0, safety_check_cdregs
-    addiu	v1, zero, 1
-    sb		v1, 0(a0)
-    lw		a0, safety_check_cdregs+8
-    addiu	v1, zero, 0x1f
-    jr		ra
-    sb		v1, 0(a0)
+	lw	a0, safechk_cdregs
+	addiu	v1, zero, 1
+	sb	v1, 0(a0)
+	lw	a0, safechk_cdregs+8
+	addiu	v1, zero, 0x1f
+	jr	ra
+	sb	v1, 0(a0)
 
+; static void SafetyCheck2( void );
 SafetyCheck2:
-    addiu 	sp, sp, -0xf8
-    addiu 	a0, zero, 1
-    sw 		ra, 0xf0(sp)
-    sw 		s1, 0xec(sp)
-    jal 	ResetGraph
-    sw 		s0, 0xe8(sp)
-    jal 	StopCallback
-    addiu 	s0, zero, 0xf0
-    jal 	ResetGraph
-    addiu 	a0, zero, 5
-    addiu 	a0, sp, 0x18
-    move 	a1, zero
-    move 	a2, zero
-    addiu 	a3, zero, 0x140
-    jal 	SetDefDrawEnv
-    sw 		s0, 0x10(sp)
-    addiu 	s1, sp, 0x78
-    move 	a0, s1
-    move 	a1, zero
-    move 	a2, zero
-    addiu 	a3, zero, 0x140
-    jal 	SetDefDispEnv
-    sw 		s0, 0x10(sp)
-    addiu 	s0, sp, 0x90
-    move 	a0, s0
-    addiu 	a1, sp, 0x18
-    addiu 	v0, zero, 1
-    jal 	SetDrawEnv
-    sb 		v0, 0x30(sp)
-    jal 	DrawPrim
-    move 	a0, s0
-    jal 	PutDispEnv
-    move 	a0, s1
-    lui 	v1, 0xe600
-    ori 	v1, v1, 2
-    addiu 	a0, sp, 0xd0
-    lui 	v0, 0x200
-    sw 		v0, 0xd0(sp)
-    sw 		v1, 0xd4(sp)
-    jal 	DrawPrim
-    sw 		zero, 0xd8(sp)
-    ori 	a2, zero, 0xffff
-    move 	s0, zero
-    addiu 	v0, zero, 0x10
-    sh		v0, 0xe4(sp)
-    addiu	v0, zero, 1
-    sh		v0, 0xe6(sp)
+	addiu	sp, sp, -0xf8
+	addiu	a0, zero, 1
+	sw	ra, 0xf0(sp)
+	sw	s1, 0xec(sp)
+	jal	ResetGraph
+	sw	s0, 0xe8(sp)
+	jal	StopCallback
+	addiu	s0, zero, 0xf0
+	jal	ResetGraph
+	addiu	a0, zero, 5
+	addiu	a0, sp, 0x18
+	move	a1, zero
+	move	a2, zero
+	addiu	a3, zero, 0x140
+	jal	SetDefDrawEnv
+	sw	s0, 0x10(sp)
+	addiu	s1, sp, 0x78
+	move	a0, s1
+	move	a1, zero
+	move	a2, zero
+	addiu	a3, zero, 0x140
+	jal	SetDefDispEnv
+	sw	s0, 0x10(sp)
+	addiu	s0, sp, 0x90
+	move	a0, s0
+	addiu	a1, sp, 0x18
+	addiu	v0, zero, 1
+	jal	SetDrawEnv
+	sb	v0, 0x30(sp)
+	jal	DrawPrim
+	move	a0, s0
+	jal	PutDispEnv
+	move	a0, s1
+	lui	v1, 0xe600
+	ori	v1, v1, 2
+	addiu	a0, sp, 0xd0
+	lui	v0, 0x200
+	sw	v0, 0xd0(sp)
+	sw	v1, 0xd4(sp)
+	jal	DrawPrim
+	sw	zero, 0xd8(sp)
+	ori	a2, zero, 0xffff
+	move	s0, zero
+	addiu	v0, zero, 0x10
+	sh	v0, 0xe4(sp)
+	addiu	v0, zero, 1
+	sh	v0, 0xe6(sp)
 
 @lab_bc:
-    la		a0, safety_check_message
-    addiu	a1, sp, 0xe0
-    addiu	v0, s0, 0x50
-    sh		v0, 0xe0(sp)
-    addiu	v0, s0, 0x5c
-    jal		SafetyCheck3
-    sh		v0, 0xe2(sp)
-    addiu	s0, s0, 1
-    slti	v0, s0, 2
-    bnez	v0, @lab_bc
-    ori		a2, zero, 0x8000
-    jal		SafetyCheck5
-    nop
-    jal		SetDispMask
-    addiu	a0, zero, 1
-    jal 	exit
-    nop
-    lw		ra, 0xf0(sp)
-    lw		s1, 0xec(sp)
-    lw		s0, 0xe8(sp)
-    jr		ra
-    addiu	sp, sp, 0xf8
+	la	a0, safechk_message
+	addiu	a1, sp, 0xe0
+	addiu	v0, s0, 0x50
+	sh	v0, 0xe0(sp)
+	addiu	v0, s0, 0x5c
+	jal	SafetyCheck3
+	sh	v0, 0xe2(sp)
+	addiu	s0, s0, 1
+	slti	v0, s0, 2
+	bnez	v0, @lab_bc
+	ori	a2, zero, 0x8000
+	jal	SafetyCheck5
+	nop
+	jal	SetDispMask
+	addiu	a0, zero, 1
+	jal	exit
+	nop
+	lw	ra, 0xf0(sp)
+	lw	s1, 0xec(sp)
+	lw	s0, 0xe8(sp)
+	jr	ra
+	addiu	sp, sp, 0xf8
 
 SafetyCheck3:
-    addiu	sp, sp, -0x30
-    sw		s0, 0x10(sp)
-    move	s0, a0
-    sw		s1, 0x14(sp)
-    move	s1, a1
-    sw		s4, 0x20(sp)
-    move	s4, a2
-    sw		ra, 0x28(sp)
-    sw		s5, 0x24(sp)
-    sw		s3, 0x1c(sp)
-    jal		strlen
-    sw		s2, 0x18(sp)
-    addu	v1, s0, v0
-    sltu	v0, s0, v1
-    lh		s3, 0(s1)
-    beqz	v0, @lab_b4
-    addiu	s5, zero, 0xa
-    move	s2, v1
+	addiu	sp, sp, -0x30
+	sw	s0, 0x10(sp)
+	move	s0, a0
+	sw	s1, 0x14(sp)
+	move	s1, a1
+	sw	s4, 0x20(sp)
+	move	s4, a2
+	sw	ra, 0x28(sp)
+	sw	s5, 0x24(sp)
+	sw	s3, 0x1c(sp)
+	jal	strlen
+	sw	s2, 0x18(sp)
+	addu	v1, s0, v0
+	sltu	v0, s0, v1
+	lh	s3, 0(s1)
+	beqz	v0, @lab_b4
+	addiu	s5, zero, 0xa
+	move	s2, v1
 
 @lab_48:
-    lbu		v0, 0(s0)
-    nop
-    bne		v0, s5, @lab_6c
-    nop
-    lhu 	v0, 2(s1)
-    sh		s3, 0(s1)
-    addiu	v0, v0, 0x12
-    j		@lab_a4
-    sh		v0, 2(s1)
+	lbu	v0, 0(s0)
+	nop
+	bne	v0, s5, @lab_6c
+	nop
+	lhu	v0, 2(s1)
+	sh	s3, 0(s1)
+	addiu	v0, v0, 0x12
+	j	@lab_a4
+	sh	v0, 2(s1)
 
 @lab_6c:
-    lbu		a0, 0(s0)
-    addiu	s0, s0, 1
-    lbu		v0, 0(s0)
-    sll		a0, a0, 8
-    jal		Krom2RawAdd
-    or		a0, v0, a0
-    move	a0, s1
-    move	a1, v0
-    jal		SafetyCheck4
-    move	a2, s4
-    lhu		v0, 0(s1)
-    nop
-    addiu	v0, v0, 0x11
-    sh		v0, 0(s1)
+	lbu	a0, 0(s0)
+	addiu	s0, s0, 1
+	lbu	v0, 0(s0)
+	sll	a0, a0, 8
+	jal	Krom2RawAdd
+	or	a0, v0, a0
+	move	a0, s1
+	move	a1, v0
+	jal	SafetyCheck4
+	move	a2, s4
+	lhu	v0, 0(s1)
+	nop
+	addiu	v0, v0, 0x11
+	sh	v0, 0(s1)
 
 @lab_a4:
-    addiu	s0, s0, 1
-    sltu	v0, s0, s2
-    bnez	v0, @lab_48
-    nop
+	addiu	s0, s0, 1
+	sltu	v0, s0, s2
+	bnez	v0, @lab_48
+	nop
 
 @lab_b4:
-    lw		ra, 0x28(sp)
-    lw		s5, 0x24(sp)
-    lw		s4, 0x20(sp)
-    lw		s3, 0x1c(sp)
-    lw		s2, 0x18(sp)
-    lw		s1, 0x14(sp)
-    lw		s0, 0x10(sp)
-    jr 		ra
-    addiu	sp, sp, 0x30
+	lw	ra, 0x28(sp)
+	lw	s5, 0x24(sp)
+	lw	s4, 0x20(sp)
+	lw	s3, 0x1c(sp)
+	lw	s2, 0x18(sp)
+	lw	s1, 0x14(sp)
+	lw	s0, 0x10(sp)
+	jr	ra
+	addiu	sp, sp, 0x30
 
 SafetyCheck4:
-    addiu	sp, sp, -0x60
-    sw		s1, 0x44(sp)
-    move 	s1, a0
-    sw 		s2, 0x48(sp)
-    move 	s2, a1
-    sw 		s4, 0x50(sp)
-    move 	s4, a2
-    sw 		ra, 0x5c(sp)
-    sw 		s6, 0x58(sp)
-    sw 		s5, 0x54(sp)
-    sw 		s3, 0x4c(sp)
-    sw 		s0, 0x40(sp)
-    lh 		s5, 0(s1)
-    lh 		s6, 2(s1)
-    lui 	v0, 0xb00
-    sw 		v0, 0x10(sp)
-    lui 	v0, 0xa000
-    sw 		v0, 0x14(sp)
-    lw 		v0, 4(s1)
-    move 	s3, zero
-    sw 		v0, 0x1c(sp)
-    addiu 	a2, sp, 0x20
+	addiu	sp, sp, -0x60
+	sw	s1, 0x44(sp)
+	move	s1, a0
+	sw	s2, 0x48(sp)
+	move	s2, a1
+	sw	s4, 0x50(sp)
+	move	s4, a2
+	sw	ra, 0x5c(sp)
+	sw	s6, 0x58(sp)
+	sw	s5, 0x54(sp)
+	sw	s3, 0x4c(sp)
+	sw	s0, 0x40(sp)
+	lh	s5, 0(s1)
+	lh	s6, 2(s1)
+	lui	v0, 0xb00
+	sw	v0, 0x10(sp)
+	lui	v0, 0xa000
+	sw	v0, 0x14(sp)
+	lw	v0, 4(s1)
+	move	s3, zero
+	sw	v0, 0x1c(sp)
+	addiu	a2, sp, 0x20
 
 @lab_58:
-    move 	s0, zero
+	move	s0, zero
 
 @lab_5c:
-    addiu 	v1, zero, 7
+	addiu	v1, zero, 7
 
 @lab_60:
-    move 	a1, a2
-    addiu 	a2, a1, 2
-    lbu 	v0, 0(s2)
-    nop
-    srav 	v0, v0, v1
-    andi 	v0, v0, 1
-    beqz 	v0, @lab_84
-    move 	a0, zero
-    move 	a0, s4
+	move	a1, a2
+	addiu	a2, a1, 2
+	lbu	v0, 0(s2)
+	nop
+	srav	v0, v0, v1
+	andi	v0, v0, 1
+	beqz	v0, @lab_84
+	move	a0, zero
+	move	a0, s4
 
 @lab_84:
-    addiu 	v1, v1, -1
-    bgez 	v1, @lab_60
-    sh 		a0, 0(a1)
-    addiu 	s0, s0, 1
-    slti 	v0, s0, 2
-    bnez 	v0, @lab_5c
-    addiu 	s2, s2, 1
-    move 	s0, zero
+	addiu	v1, v1, -1
+	bgez	v1, @lab_60
+	sh	a0, 0(a1)
+	addiu	s0, s0, 1
+	slti	v0, s0, 2
+	bnez	v0, @lab_5c
+	addiu	s2, s2, 1
+	move	s0, zero
 
 @lab_a4:
-    lw 		v0, 0(s1)
-    addiu 	a0, sp, 0x10
-    jal 	DrawPrim
-    sw 		v0, 0x18(sp)
-    lhu 	v0, 0(s1)
-    addiu 	s0, s0, 1
-    addiu 	v0, v0, 1
-    sh 		v0, 0(s1)
-    slti 	v0, s0, 2
-    bnez 	v0, @lab_a4
-    nop
-    lhu 	v0, 2(s1)
-    addiu 	s3, s3, 1
-    sh 		s5, 0(s1)
-    addiu 	v0, v0, 1
-    sh 		v0, 2(s1)
-    slti 	v0, s3, 0xf
-    bnez 	v0, @lab_58
-    addiu 	a2, sp, 0x20
-    sh 		s6, 2(s1)
-    lw 		ra, 0x5c(sp)
-    lw 		s6, 0x58(sp)
-    lw 		s5, 0x54(sp)
-    lw 		s4, 0x50(sp)
-    lw 		s3, 0x4c(sp)
-    lw 		s2, 0x48(sp)
-    lw 		s1, 0x44(sp)
-    lw 		s0, 0x40(sp)
-    jr 		ra
-    addiu 	sp, sp, 0x60
+	lw	v0, 0(s1)
+	addiu	a0, sp, 0x10
+	jal	DrawPrim
+	sw	v0, 0x18(sp)
+	lhu	v0, 0(s1)
+	addiu	s0, s0, 1
+	addiu	v0, v0, 1
+	sh	v0, 0(s1)
+	slti	v0, s0, 2
+	bnez	v0, @lab_a4
+	nop
+	lhu	v0, 2(s1)
+	addiu	s3, s3, 1
+	sh	s5, 0(s1)
+	addiu	v0, v0, 1
+	sh	v0, 2(s1)
+	slti	v0, s3, 0xf
+	bnez	v0, @lab_58
+	addiu	a2, sp, 0x20
+	sh	s6, 2(s1)
+	lw	ra, 0x5c(sp)
+	lw	s6, 0x58(sp)
+	lw	s5, 0x54(sp)
+	lw	s4, 0x50(sp)
+	lw	s3, 0x4c(sp)
+	lw	s2, 0x48(sp)
+	lw	s1, 0x44(sp)
+	lw	s0, 0x40(sp)
+	jr	ra
+	addiu	sp, sp, 0x60
 
 SafetyCheck5:
-    addiu	sp, sp, -0x50
-    lui		v1, 0x2800
-    ori		v1, v1, 0xff
-    sw		s2, 0x38(sp)
-    move	s2, zero
-    sw		s4, 0x40(sp)
-    addiu	s4, sp, 0x10
-    sw		s6, 0x48(sp)
-    addiu	s6, sp, 0x28
-    sw		s5, 0x44(sp)
-    addiu 	s5, zero, 0x10
-    sw 		s3, 0x3c(sp)
-    la 		s3, safety_check_coords
-    lui 	v0, 0x500
-    sw		ra, 0x4c(sp)
-    sw		s1, 0x34(sp)
-    sw		s0, 0x30(sp)
-    sw		v0, 0x10(sp)
-    sw		v1, 0x14(sp)
+	addiu	sp, sp, -0x50
+	lui	v1, 0x2800
+	ori	v1, v1, 0xff
+	sw	s2, 0x38(sp)
+	move	s2, zero
+	sw	s4, 0x40(sp)
+	addiu	s4, sp, 0x10
+	sw	s6, 0x48(sp)
+	addiu	s6, sp, 0x28
+	sw	s5, 0x44(sp)
+	addiu	s5, zero, 0x10
+	sw	s3, 0x3c(sp)
+	la	s3, safechk_coords
+	lui	v0, 0x500
+	sw	ra, 0x4c(sp)
+	sw	s1, 0x34(sp)
+	sw	s0, 0x30(sp)
+	sw	v0, 0x10(sp)
+	sw	v1, 0x14(sp)
 
 @lab_50:
-    move	s1, zero
-    move	s0, s6
+	move	s1, zero
+	move	s0, s6
 
 @lab_58:
-    la 		a1, safety_check_offset
-    lwl 	v0, 3(a1)
-    lwr 	v0, 0(a1)
-    lwl 	v1, 7(a1)
-    lwr 	v1, 4(a1)
-    swl 	v0, 0x2b(sp)
-    swr 	v0, 0x28(sp)
-    swl 	v1, 0x2f(sp)
-    swr 	v1, 0x2c(sp)
-    move 	a2, zero
-    move 	t1, s0
-    move 	t0, s4
+	la	a1, safechk_offset
+	lwl	v0, 3(a1)
+	lwr	v0, 0(a1)
+	lwl	v1, 7(a1)
+	lwr	v1, 4(a1)
+	swl	v0, 0x2b(sp)
+	swr	v0, 0x28(sp)
+	swl	v1, 0x2f(sp)
+	swr	v1, 0x2c(sp)
+	move	a2, zero
+	move	t1, s0
+	move	t0, s4
 
 @lab_8c:
-    addiu	a1, a2, 2
-    sra 	a1, a1, 2
-    andi 	v1, a2, 1
-    addu 	v1, s2, v1
-    subu 	v0, s5, v1
-    sll 	v0, v0, 1
-    addu 	v0, v0, s3
-    addu 	v0, v0, a1
-    lb 		a0, 1(t1)
-    lbu 	v0, 0(v0)
-    nop
-    mult 	a0, v0
-    sll 	v1, v1, 1
-    addu 	v1, v1, s3
-    addu 	v1, v1, a1
-    lb 		a0, 0(t1)
-    mflo 	a3
-    lbu 	v0, 0(v1)
-    nop
-    mult 	a0, v0
-    addiu 	a2, a2, 1
-    addiu 	v0, a3, 0x78
-    sll 	v0, v0, 0x10
-    mflo 	v1
-    addiu 	v1, v1, 0xa0
-    or 		v0, v0, v1
-    sw 		v0, 8(t0)
-    slti 	v0, a2, 4
-    bnez 	v0, @lab_8c
-    addiu 	t0, t0, 4
-    jal 	DrawPrim
-    addiu 	a0, sp, 0x10
-    addiu 	s1, s1, 1
-    slti 	v0, s1, 4
-    bnez 	v0, @lab_58
-    addiu 	s0, s0, 2
-    addiu 	s2, s2, 1
-    slti 	v0, s2, 0x10
-    bnez 	v0, @lab_50
-    lui 	a2, 0x50
-    ori 	a2, a2, 0x70
-    lui 	a1, 0x48
-    ori 	a1, a1, 0x78
-    lui 	v1, 0xa8
-    ori 	v1, v1, 0xc8
-    lui 	v0, 0xa0
-    ori 	v0, v0, 0xd0
-    addiu 	a0, sp, 0x10
-    sw 		a2, 0x18(sp)
-    sw 		a1, 0x1c(sp)
-    sw 		v1, 0x20(sp)
-    jal 	DrawPrim
-    sw 		v0, 0x24(sp)
-    lw 		ra, 0x4c(sp)
-    lw 		s6, 0x48(sp)
-    lw 		s5, 0x44(sp)
-    lw 		s4, 0x40(sp)
-    lw 		s3, 0x3c(sp)
-    lw 		s2, 0x38(sp)
-    lw 		s1, 0x34(sp)
-    lw 		s0, 0x30(sp)
-    jr 		ra
-    addiu 	sp, sp, 0x50
-    nop
+	addiu	a1, a2, 2
+	sra	a1, a1, 2
+	andi	v1, a2, 1
+	addu	v1, s2, v1
+	subu	v0, s5, v1
+	sll	v0, v0, 1
+	addu	v0, v0, s3
+	addu	v0, v0, a1
+	lb	a0, 1(t1)
+	lbu	v0, 0(v0)
+	nop
+	mult	a0, v0
+	sll	v1, v1, 1
+	addu	v1, v1, s3
+	addu	v1, v1, a1
+	lb	a0, 0(t1)
+	mflo	a3
+	lbu	v0, 0(v1)
+	nop
+	mult	a0, v0
+	addiu	a2, a2, 1
+	addiu	v0, a3, 0x78
+	sll	v0, v0, 0x10
+	mflo	v1
+	addiu	v1, v1, 0xa0
+	or	v0, v0, v1
+	sw	v0, 8(t0)
+	slti	v0, a2, 4
+	bnez	v0, @lab_8c
+	addiu	t0, t0, 4
+	jal	DrawPrim
+	addiu	a0, sp, 0x10
+	addiu	s1, s1, 1
+	slti	v0, s1, 4
+	bnez	v0, @lab_58
+	addiu	s0, s0, 2
+	addiu	s2, s2, 1
+	slti	v0, s2, 0x10
+	bnez	v0, @lab_50
+	lui	a2, 0x50
+	ori	a2, a2, 0x70
+	lui	a1, 0x48
+	ori	a1, a1, 0x78
+	lui	v1, 0xa8
+	ori	v1, v1, 0xc8
+	lui	v0, 0xa0
+	ori	v0, v0, 0xd0
+	addiu	a0, sp, 0x10
+	sw	a2, 0x18(sp)
+	sw	a1, 0x1c(sp)
+	sw	v1, 0x20(sp)
+	jal	DrawPrim
+	sw	v0, 0x24(sp)
+	lw	ra, 0x4c(sp)
+	lw	s6, 0x48(sp)
+	lw	s5, 0x44(sp)
+	lw	s4, 0x40(sp)
+	lw	s3, 0x3c(sp)
+	lw	s2, 0x38(sp)
+	lw	s1, 0x34(sp)
+	lw	s0, 0x30(sp)
+	jr	ra
+	addiu	sp, sp, 0x50
+	nop
 
-    section .data
+	section .data
 
 __ps_libinfo__:
-    db		'P','s'     ;
-    db		28          ; "safechk"
-    db		0,0,0       ;
-    db		$10         ; 1.0.0.3
-    db		$03         ;
+	db	'P','s'         ;
+	db	28              ; "safechk"
+	db	0,0,0           ;
+	db	$10,$03         ; 1.0.0.3
 
-safety_check_commands:
-    dw		$03010001
-    dw		$05010007
-    dw		$03010302
-    dw		$05010016
-    dw		$0301010E
-    dw		$03040119
-    dw		$0301000B
-    dw		$03010003
-    dw		$03020119
-    dw		$05010009
+safechk_commands:
+	dw	$03010001
+	dw	$05010007
+	dw	$03010302
+	dw	$05010016
+	dw	$0301010E
+	dw	$03040119
+	dw	$0301000B
+	dw	$03010003
+	dw	$03020119
+	dw	$05010009
 
-safety_check_cdregs:
-    dw		$1F801800	; CD_STAT
-    dw		$1F801801	; CD_CMD
-    dw		$1F801802	; CD_DATA
-    dw		$1F801803	; CD_IRQ
+safechk_cdregs:
+	dw	$1F801800	; CD_STAT
+	dw	$1F801801	; CD_CMD
+	dw	$1F801802	; CD_DATA
+	dw	$1F801803	; CD_IRQ
 
-safety_check_params:
-    db		0, 0, 0, 0, 0, 0, 0, 0
+; static unsigned char safechk_params[];
+safechk_params:
+	db	0, 0, 0, 0, 0, 0, 0, 0
 
-safety_check_results:
-    db		0, 0, 0, 0, 0, 0, 0, 0
+; static unsigned char safechk_results[];
+safechk_results:
+	db	0, 0, 0, 0, 0, 0, 0, 0
 
-safety_check_coords:
-    db		0, 0
-    db		6, 5
-    db		12, 10
-    db		18, 15
-    db		24, 20
-    db		30, 25
-    db		35, 30
-    db		40, 34
-    db		45, 38
-    db		49, 41
-    db		53, 44
-    db		56, 47
-    db		59, 49
-    db		61, 51
-    db		62, 52
-    db		63, 53
-    db		64, 54
-    db		0, 0
-    db		0, 0
-    db		0, 0
-    db		0, 0
-    db		0, 0
-    db		0, 0
-    db		0, 0
+safechk_coords:
+	db	0, 0
+	db	6, 5
+	db	12, 10
+	db	18, 15
+	db	24, 20
+	db	30, 25
+	db	35, 30
+	db	40, 34
+	db	45, 38
+	db	49, 41
+	db	53, 44
+	db	56, 47
+	db	59, 49
+	db	61, 51
+	db	62, 52
+	db	63, 53
+	db	64, 54
+	db	0, 0
+	db	0, 0
+	db	0, 0
+	db	0, 0
+	db	0, 0
+	db	0, 0
+	db	0, 0
 
-    section .rdata
+	section .rdata
 
 ; "強制終了しました。\n本体が改造されている\nおそれがあります。"
-safety_check_message:
-    db      $8B,$AD, $90,$A7, $8F,$49, $97,$B9
-    db      $82,$B5, $82,$DC, $82,$B5, $82,$BD
-    db      $81,$42, $0A,     $96,$7B, $91,$CC
-    db      $82,$AA, $89,$FC, $91,$A2, $82,$B3
-    db      $82,$EA, $82,$C4, $82,$A2, $82,$E9
-    db      $0A,     $82,$A8, $82,$BB, $82,$EA
-    db      $82,$AA, $82,$A0, $82,$E8, $82,$DC
-    db      $82,$B7, $81,$42, $00,$00
+safechk_message:
+	db	$8B,$AD, $90,$A7, $8F,$49, $97,$B9
+	db	$82,$B5, $82,$DC, $82,$B5, $82,$BD
+	db	$81,$42, $0A,     $96,$7B, $91,$CC
+	db	$82,$AA, $89,$FC, $91,$A2, $82,$B3
+	db	$82,$EA, $82,$C4, $82,$A2, $82,$E9
+	db	$0A,     $82,$A8, $82,$BB, $82,$EA
+	db	$82,$AA, $82,$A0, $82,$E8, $82,$DC
+	db	$82,$B7, $81,$42, $00,$00
 
-safety_check_offset:
-    dh 		257, 511
-    dh 		-255, -1
-    dh 		0, 0
-    dh 		0, 0
-    dh 		0, 0
+safechk_offset:
+	dh	257, 511
+	dh	-255, -1
+	dh	0, 0
+	dh	0, 0
+	dh	0, 0

--- a/asm/SAFECHK.s
+++ b/asm/SAFECHK.s
@@ -629,8 +629,12 @@ SafetyCheck5:
 
     section .data
 
-    ; library identifier
-    dw		$001C7350, $03100000
+__ps_libinfo__:
+    db		'P','s'     ;
+    db		28          ; "safechk"
+    db		0,0,0       ;
+    db		$10         ; 1.0.0.3
+    db		$03         ;
 
 safety_check_commands:
     dw		$03010001
@@ -645,10 +649,10 @@ safety_check_commands:
     dw		$05010009
 
 safety_check_cdregs:
-    dw		$1F801800
-    dw		$1F801801
-    dw		$1F801802
-    dw		$1F801803
+    dw		$1F801800	; CD_STAT
+    dw		$1F801801	; CD_CMD
+    dw		$1F801802	; CD_DATA
+    dw		$1F801803	; CD_IRQ
 
 safety_check_params:
     db		0, 0, 0, 0, 0, 0, 0, 0
@@ -684,68 +688,16 @@ safety_check_coords:
 
     section .rdata
 
-; 強制終了しました。 本体が改造されている おそれがあります。
+; "強制終了しました。\n本体が改造されている\nおそれがあります。"
 safety_check_message:
-    db		$8B
-    db		$AD
-    db		$90
-    db		$A7
-    db		$8F
-    db		$49
-    db		$97
-    db		$B9
-    db		$82
-    db		$B5
-    db		$82
-    db		$DC
-    db		$82
-    db		$B5
-    db		$82
-    db		$BD
-    db		$81
-    db		$42
-    db		$0A
-    db		$96
-    db		$7B
-    db		$91
-    db		$CC
-    db		$82
-    db		$AA
-    db		$89
-    db		$FC
-    db		$91
-    db		$A2
-    db		$82
-    db		$B3
-    db		$82
-    db		$EA
-    db		$82
-    db		$C4
-    db		$82
-    db		$A2
-    db		$82
-    db		$E9
-    db		$0A
-    db		$82
-    db		$A8
-    db		$82
-    db		$BB
-    db		$82
-    db		$EA
-    db		$82
-    db		$AA
-    db		$82
-    db		$A0
-    db		$82
-    db		$E8
-    db		$82
-    db		$DC
-    db		$82
-    db		$B7
-    db		$81
-    db		$42
-    db		$00
-    db		$00
+    db      $8B,$AD, $90,$A7, $8F,$49, $97,$B9
+    db      $82,$B5, $82,$DC, $82,$B5, $82,$BD
+    db      $81,$42, $0A,     $96,$7B, $91,$CC
+    db      $82,$AA, $89,$FC, $91,$A2, $82,$B3
+    db      $82,$EA, $82,$C4, $82,$A2, $82,$E9
+    db      $0A,     $82,$A8, $82,$BB, $82,$EA
+    db      $82,$AA, $82,$A0, $82,$E8, $82,$DC
+    db      $82,$B7, $81,$42, $00,$00
 
 safety_check_offset:
     dh 		257, 511

--- a/src/Equip/bandana.c
+++ b/src/Equip/bandana.c
@@ -4,8 +4,6 @@
 
 extern short GM_Magazine_800AB9EC;
 
-extern short gGcl_gameStateVars_800B44C8[0x60];
-
 extern short snake_weapon_idx_800BDCBA;
 extern short snake_weapon_max_ammo_800BDCBC;
 extern short GM_Magazine_800AB9EC;

--- a/src/Game/linkvarbuf.h
+++ b/src/Game/linkvarbuf.h
@@ -1,8 +1,8 @@
 #ifndef _LINKVARBUF_H_
 #define _LINKVARBUF_H_
 
-extern short       gGameState_800B4D98[0x60];
-#define linkvarbuf gGameState_800B4D98
+extern short       linkvarbuf_800B4D98[0x60];
+#define linkvarbuf linkvarbuf_800B4D98
 
 //------------------------------------------------------------------------------
 // 0x00 General

--- a/src/Game/object.c
+++ b/src/Game/object.c
@@ -40,7 +40,7 @@ void sub_800348F4(OBJECT *obj)
     long intime, outtime;
     intime = GetRCnt(RCntCNT1);
 
-    SetSpadStack(DCache);
+    SetSpadStack(SPAD_STACK_ADDR);
     sub_8003556C(obj->m_ctrl); // motion streaming related
     ResetSpadStack();
 

--- a/src/Game/script.c
+++ b/src/Game/script.c
@@ -1,4 +1,5 @@
 #include "linker.h"
+#include "common.h"
 #include "libgcl/libgcl.h"
 #include "libgcl/hash.h"
 #include "mts/mts_new.h"

--- a/src/Menu/weapon.c
+++ b/src/Menu/weapon.c
@@ -1120,7 +1120,7 @@ void menu_weapon_update_helper2_helper2_8003E3B0(Actor_MenuMan *work)
 {
     Menu_Item_Unknown *pItemUnknown;
     int                id;
-    short             *gameState;
+    short             *varbuf;
 
     pItemUnknown = work->field_1F0_menu_weapon.field_C_alloc;
     work->field_1F0_menu_weapon.field_10_state = 0;
@@ -1129,7 +1129,7 @@ void menu_weapon_update_helper2_helper2_8003E3B0(Actor_MenuMan *work)
                              &pItemUnknown->field_20_array[pItemUnknown->field_0_main.field_4_selected_idx]);
 
     id = work->field_1F0_menu_weapon.field_0_current.field_0_id;
-    gameState = gGameState_800B4D98;
+    varbuf = linkvarbuf_800B4D98;
 
     if (id >= 0 && !sub_8003DF30(id))
     {
@@ -1140,7 +1140,7 @@ void menu_weapon_update_helper2_helper2_8003E3B0(Actor_MenuMan *work)
             sub_8003CFE0(
                 menu_weapon_get_weapon_rpk_info_8003DED8(work->field_1F0_menu_weapon.field_0_current.field_0_id), 1);
         }
-        work->field_1F0_menu_weapon.field_11 = gameState[14]; // GM_CurrentWeaponId would not match...
+        work->field_1F0_menu_weapon.field_11 = varbuf[14]; // GM_CurrentWeaponId would not match...
     }
     else
     {

--- a/src/Okajima/spark.c
+++ b/src/Okajima/spark.c
@@ -310,7 +310,7 @@ GV_ACT *NewSpark_80074564(MATRIX *pMatrix, int pCnt)
         {
             GV_SetNamedActor_8001514C(&work->actor, (TActorFunction)spark_act_80074334, (TActorFunction)spark_kill_800743DC, "spark.c");
 
-            SetSpadStack(DCache);
+            SetSpadStack(SPAD_STACK_ADDR);
             if (SparkGetResources_80074418(work, pMatrix, pCnt) < 0)
             {
                 ResetSpadStack();

--- a/src/common.h
+++ b/src/common.h
@@ -13,9 +13,13 @@
 // These macros were taken from "GTE Advanced Topics" (slide 18),
 // originally presented at the March 1996 PlayStation Developer's Conference.
 //
-// "spadstk.h" from the SDK's texture address modulation sample
-// (psx/sample/graphics/texaddr/wave) defines slightly modified versions
-// of SetSpadStack/ResetSpadStack that add/sub 24 from $sp instead of 4.
+// According to stack.txt (in Japanese) from the seminar sample code,
+// compiler optimizations should be set to -O1 or higher, otherwise
+// the $fp register may be used, potentially resulting in a crash.
+//
+// In addition, function calls with 5 or more arguments will use the stack
+// for passing the 5th argument onwards. The callee will receive garbage data
+// if these are set before the stack switch.
 
 // clang-format off
 /* scratch pad address 0x1f800000 - 0x1f800400 */
@@ -29,13 +33,13 @@
 }
 
 #define ResetSpadStack() { \
-    __asm__ volatile ("addiu $29,$29,4" :::"$29","memory"); \
-    __asm__ volatile ("lw $29,0($29)"   :::"$29","memory"); \
+    __asm__ volatile ("addiu $29,$29,4":::"$29","memory"); \
+    __asm__ volatile ("lw $29,0($29)"  :::"$29","memory"); \
 }
 
 #define GetStackAddr(addr) { \
-    __asm__ volatile ("move $8,%0"  ::"r"(addr):"$8","memory"); \
-    __asm__ volatile ("sw $29,0($8)"::         :"$8","memory"); \
+    __asm__ volatile ("move $8,%0"     ::"r"(addr):"$8","memory"); \
+    __asm__ volatile ("sw $29,0($8)"   ::         :"$8","memory"); \
 }
 // clang-format on
 

--- a/src/common.h
+++ b/src/common.h
@@ -8,6 +8,8 @@
 
 #define ABS(x) (((x) >= 0) ? (x) : -(x))
 
+#define COUNTOF(array) (sizeof(array) / sizeof(array[0]))
+
 // These macros were taken from "GTE Advanced Topics" (slide 18),
 // originally presented at the March 1996 PlayStation Developer's Conference.
 //

--- a/src/common.h
+++ b/src/common.h
@@ -8,22 +8,33 @@
 
 #define ABS(x) (((x) >= 0) ? (x) : -(x))
 
-#define DCache 0x1F8003FC
+// These macros were taken from "GTE Advanced Topics" (slide 18),
+// originally presented at the March 1996 PlayStation Developer's Conference.
+//
+// "spadstk.h" from the SDK's texture address modulation sample
+// (psx/sample/graphics/texaddr/wave) defines slightly modified versions
+// of SetSpadStack/ResetSpadStack that add/sub 24 from $sp instead of 4.
 
-// Put stack on scratchpad
-#define SetSpadStack(addr)                                                                                             \
-    {                                                                                                                  \
-        __asm__ volatile("move $8,%0" ::"r"(addr) : "$8", "memory");                                                   \
-        __asm__ volatile("sw $29,0($8)" ::: "$8", "memory");                                                           \
-        __asm__ volatile("addiu $8,$8,-4" ::: "$8", "memory");                                                         \
-        __asm__ volatile("move $29,$8" ::: "$8", "memory");                                                            \
-    }
+// clang-format off
+/* scratch pad address 0x1f800000 - 0x1f800400 */
+#define SPAD_STACK_ADDR 0x1f8003fc
 
-// reset scratchpad stack
-#define ResetSpadStack()                                                                                               \
-    {                                                                                                                  \
-        __asm__ volatile("addiu $29,$29,4" ::: "$29", "memory");                                                       \
-        __asm__ volatile("lw $29,0($29)" ::: "$29", "memory");                                                         \
-    }
+#define SetSpadStack(addr) { \
+    __asm__ volatile ("move $8,%0"     ::"r"(addr):"$8","memory"); \
+    __asm__ volatile ("sw $29,0($8)"   ::         :"$8","memory"); \
+    __asm__ volatile ("addiu $8,$8,-4" ::         :"$8","memory"); \
+    __asm__ volatile ("move $29,$8"    ::         :"$8","memory"); \
+}
+
+#define ResetSpadStack() { \
+    __asm__ volatile ("addiu $29,$29,4" :::"$29","memory"); \
+    __asm__ volatile ("lw $29,0($29)"   :::"$29","memory"); \
+}
+
+#define GetStackAddr(addr) { \
+    __asm__ volatile ("move $8,%0"  ::"r"(addr):"$8","memory"); \
+    __asm__ volatile ("sw $29,0($8)"::         :"$8","memory"); \
+}
+// clang-format on
 
 #endif // _COMMON_H_

--- a/src/data/bss.c
+++ b/src/data/bss.c
@@ -84,10 +84,10 @@ gap                                     gap_800B3C24[0x4]; // 4 bytes
 int BSS             argstack_800B3C28[32]; // 0x80 (128) bytes
 unsigned char *BSS  commandlines_800B3CA8[8]; // 0x20 (32) bytes
 GCL_Vars BSS        gGcl_vars_800B3CC8; // 0x800 (2048) bytes
-short BSS           gGcl_gameStateVars_800B44C8[0x60]; // 0xC0 (192) bytes
+short BSS           sv_linkvarbuf_800B44C8[0x60]; // 0xC0 (192) bytes
 GCL_Vars BSS        gGcl_memVars_800b4588; // 0x800 (2048) bytes
 char BSS            gStageName_800B4D88[16]; // 0x10 (16) bytes
-short BSS           gGameState_800B4D98[0x60]; // 0xC0 (192) bytes
+short BSS           linkvarbuf_800B4D98[0x60]; // 0xC0 (192) bytes
 CDBIOS_TASK BSS     cd_bios_task_800B4E58; // 0x24 (36) bytes
 
 gap                                     gap_800B4E7C[0xC]; // 12 bytes

--- a/src/libdg/Light.c
+++ b/src/libdg/Light.c
@@ -1,6 +1,7 @@
 #include "linker.h"
 #include "libdg.h"
 #include "psyq.h"
+#include "common.h"
 
 /**data*********************************************************/
 MATRIX DG_LightMatrix_8009D384 = {

--- a/src/libdg/divide.c
+++ b/src/libdg/divide.c
@@ -598,7 +598,7 @@ void DG_DivideChanl_80019D44( DG_CHNL* chnl, int idx )
                         get_mem()->field_10 = x;
                     }
 
-                    SetSpadStack( DCache );
+                    SetSpadStack( SPAD_STACK_ADDR );
                     DG_InitRVector_8001991C( obj, idx );
                     ResetSpadStack();
 

--- a/src/libfs/cdbios.c
+++ b/src/libfs/cdbios.c
@@ -15,7 +15,7 @@ extern const char  *MGS_DiskName_8009D2FC[3];
 
 void MakeFullPath_80021F68(int name, char *buffer)
 {
-
+    /* do nothing */
 }
 
 int CDBIOS_Reset_80021F70(void)
@@ -406,15 +406,15 @@ int FS_CdMakePositionTable_helper2_800228D4(void *pBuffer, int startSector, int 
     return 1;
 }
 
-FS_FILE_INFO_8009D49C *FS_FindDirEntry_80022918(char *pFileName, FS_FILE_INFO_8009D49C *pFile)
+FS_FILE_INFO *FS_FindDirEntry_80022918(char *pFileName, FS_FILE_INFO *pFileInfo)
 {
-    FS_FILE_INFO_8009D49C *file;
+    FS_FILE_INFO *info;
 
-    for (file = pFile; file->pDatName; file++)
+    for (info = pFileInfo; info->name; info++)
     {
-        if (!strcmp(pFileName, file->pDatName))
+        if (!strcmp(pFileName, info->name))
         {
-            return file;
+            return info;
         }
     }
 
@@ -438,25 +438,25 @@ static inline char getXAUserID(int directoryRecord, int fileIdentifierLength, in
 
 #define byteswap_ulong(p) p[0] | (p[1] << 8) | (p[2] << 16) | (p[3] << 24)
 
-int FS_CdMakePositionTable_helper_8002297C(char *inDirectoryRecord, FS_FILE_INFO_8009D49C *inDirectoryRecords)
+int FS_CdMakePositionTable_helper_8002297C(char *inDirectoryRecord, FS_FILE_INFO *inDirectoryRecords)
 {
-    FS_FILE_INFO_8009D49C *foundRecord;
-    const char           **diskNameIterator;
-    const char            *currentStringPtr;
-    int                    fileIdentifierLength;
-    char                   parsedFileName[32];
-    char                  *sectorBaseValues;
-    char                  *topValues;
-    char                  *sizeValues;
-    int                    sectorBase;
-    int                    top;
-    int                    size;
-    int                    returnValue;
-    int                    stringCount;
-    int                    basicRecordLength;
-    char                  *fileIdentifier;
-    char                  *directoryRecord;
-    FS_FILE_INFO_8009D49C *directoryRecords;
+    FS_FILE_INFO    *foundRecord;
+    const char     **diskNameIterator;
+    const char      *currentStringPtr;
+    int              fileIdentifierLength;
+    char             parsedFileName[32];
+    char            *sectorBaseValues;
+    char            *topValues;
+    char            *sizeValues;
+    int              sectorBase;
+    int              top;
+    int              size;
+    int              returnValue;
+    int              stringCount;
+    int              basicRecordLength;
+    char            *fileIdentifier;
+    char            *directoryRecord;
+    FS_FILE_INFO    *directoryRecords;
 
     directoryRecords = inDirectoryRecords;
     directoryRecord = inDirectoryRecord;
@@ -481,13 +481,13 @@ int FS_CdMakePositionTable_helper_8002297C(char *inDirectoryRecord, FS_FILE_INFO
 
                     if (parsedFileName[0] == 'Z' && getXAUserID((int)directoryRecord, fileIdentifierLength, basicRecordLength) == 0xd)
                     {
-                        foundRecord->field_4_sector = 0;
+                        foundRecord->sector = 0;
                     }
                     else
                     {
                         sectorBaseValues = (directoryRecord + 2);
                         sectorBase = byteswap_ulong(sectorBaseValues);
-                        foundRecord->field_4_sector = sectorBase + 150;
+                        foundRecord->sector = sectorBase + 150;
                     }
                 }
                 else
@@ -515,7 +515,7 @@ int FS_CdMakePositionTable_helper_8002297C(char *inDirectoryRecord, FS_FILE_INFO
                 sizeValues = (directoryRecord + 10);
                 size = byteswap_ulong(sizeValues);
 
-                printf("FILE %s : top %d size %d set %d\n", parsedFileName, top, size, foundRecord->field_4_sector);
+                printf("FILE %s : top %d size %d set %d\n", parsedFileName, top, size, foundRecord->sector);
             }
         }
 
@@ -525,7 +525,7 @@ int FS_CdMakePositionTable_helper_8002297C(char *inDirectoryRecord, FS_FILE_INFO
     return returnValue;
 }
 
-int FS_CdMakePositionTable_80022B5C(char *pHeap, FS_FILE_INFO_8009D49C *pDirRecs)
+int FS_CdMakePositionTable_80022B5C(char *pHeap, FS_FILE_INFO *pDirRecs)
 {
     char *buffer2;
     char *dir_block_ptr;

--- a/src/libfs/fscd.c
+++ b/src/libfs/fscd.c
@@ -1,6 +1,6 @@
 #include "libfs.h"
 
-FS_FILE_INFO_8009D49C gDirFiles_8009D49C[] = {
+FS_FILE_INFO fs_file_info_8009D49C[] = {
     {"STAGE.DIR", 0},
     {"RADIO.DAT", 0},
     {"FACE.DAT", 0},
@@ -15,13 +15,13 @@ extern int gDiskNum_800ACBF0;
 
 int FS_ResetCdFilePosition_80021E2C(void *pHeap)
 {
-    int disk_num = FS_CdMakePositionTable_80022B5C(pHeap, gDirFiles_8009D49C);
+    int disk_num = FS_CdMakePositionTable_80022B5C(pHeap, fs_file_info_8009D49C);
     printf("Position end\n");
     if (disk_num >= 0)
     {
         printf("DISK %d\n", disk_num);
-        FS_CdStageFileInit_80022D00(pHeap, gDirFiles_8009D49C[0].field_4_sector);
-        FS_MovieFileInit_80023860(pHeap, gDirFiles_8009D49C[3].field_4_sector);
+        FS_CdStageFileInit_80022D00(pHeap, fs_file_info_8009D49C[0].sector);
+        FS_MovieFileInit_80023860(pHeap, fs_file_info_8009D49C[3].sector);
     }
     else
     {
@@ -42,7 +42,7 @@ void CDFS_Init_80021EC4()
 
 void FS_LoadFileRequest_80021F0C(int dirFile, int startSector, int sectorSize, void *pBuffer)
 {
-    CDBIOS_ReadRequest_8002280C(pBuffer, gDirFiles_8009D49C[dirFile].field_4_sector + startSector, sectorSize, 0);
+    CDBIOS_ReadRequest_8002280C(pBuffer, fs_file_info_8009D49C[dirFile].sector + startSector, sectorSize, 0);
 }
 
 int FS_LoadFileSync_80021F48(void)

--- a/src/libfs/libfs.h
+++ b/src/libfs/libfs.h
@@ -4,11 +4,11 @@
 #include "cdbios.h"
 #include "Game/loader.h"
 
-typedef struct _FS_FILE_INFO_8009D49C
+typedef struct _FS_FILE_INFO
 {
-    const char *pDatName;
-    int         field_4_sector;
-} FS_FILE_INFO_8009D49C;
+    const char *name;
+    int         sector;
+} FS_FILE_INFO;
 
 // TODO: This is a stage file
 typedef struct _FS_FILE {
@@ -47,7 +47,7 @@ typedef char * (*TFsCallback)(char *);
 typedef void (*TFsSoundCallback)(void);
 
 int         CDBIOS_ReadSync_80022854(void);
-int         FS_CdMakePositionTable_80022B5C(char *pHeap, FS_FILE_INFO_8009D49C *pDirRecs);
+int         FS_CdMakePositionTable_80022B5C(char *pHeap, FS_FILE_INFO *pDirRecs);
 int         FS_ResetCdFilePosition_80021E2C(void *pHeap);
 void        CDBIOS_ForceStop_80022864(void);
 int         CDBIOS_Reset_80021F70(void);
@@ -76,7 +76,7 @@ int         FS_LoadFileSync_80021F48(void);
 void        CDBIOS_TaskStart_800227A8(void);
 void        CDBIOS_Main_80022264(void);
 int         FS_CdStageFileInit_helper_80022CBC(CDBIOS_TASK *task);
-int         FS_CdMakePositionTable_helper_8002297C(char *pDirBlock, FS_FILE_INFO_8009D49C *pDirRecs);
+int         FS_CdMakePositionTable_helper_8002297C(char *pDirBlock, FS_FILE_INFO *pDirRecs);
 int         FS_StreamGetTop_80023F94(int is_movie);
 void        FS_StreamTaskStart_80023D94(int param_1);
 int         FS_StreamInit_80023FD4(void *pHeap, int heapSize);

--- a/src/libfs/stream.c
+++ b/src/libfs/stream.c
@@ -10,18 +10,18 @@ int  fs_stream_is_force_stop_8009D518 = 0;
 int  fs_stream_end_flag_8009D51C = 1;
 int *fs_dword_8009D520 = NULL;
 
-extern FS_FILE_INFO_8009D49C gDirFiles_8009D49C[];
-extern int                   fs_stream_ref_count_800B5298;
-extern int                   fs_dword_800B529C;
-extern int                   fs_dword_800B52A0;
-extern void                 *fs_stream_heap_800B52A4;
-extern char                 *fs_stream_heap_end_800B52A8;
-extern int                   fs_stream_heapSize_800B52AC;
-extern void                 *fs_dword_800B52B0;
-extern char                 *fs_ptr_800B52B4;
-extern int                  *fs_ptr_800B52B8;
-extern char                 *fs_ptr_800B52BC;
-extern int                   fs_stream_task_state_800B52C0;
+extern FS_FILE_INFO fs_file_info_8009D49C[];
+extern int          fs_stream_ref_count_800B5298;
+extern int          fs_dword_800B529C;
+extern int          fs_dword_800B52A0;
+extern void         *fs_stream_heap_800B52A4;
+extern char         *fs_stream_heap_end_800B52A8;
+extern int          fs_stream_heapSize_800B52AC;
+extern void         *fs_dword_800B52B0;
+extern char         *fs_ptr_800B52B4;
+extern int          *fs_ptr_800B52B8;
+extern char         *fs_ptr_800B52BC;
+extern int          fs_stream_task_state_800B52C0;
 
 int sub_800239E8(CDBIOS_TASK *pTask)
 {
@@ -322,7 +322,7 @@ int FS_StreamGetTop_80023F94(int is_movie)
         dir_idx = 5;
         break;
     }
-    return gDirFiles_8009D49C[dir_idx].field_4_sector;
+    return fs_file_info_8009D49C[dir_idx].sector;
 }
 
 int FS_StreamInit_80023FD4(void *pHeap, int heapSize)

--- a/src/libgcl/basic.c
+++ b/src/libgcl/basic.c
@@ -1,4 +1,5 @@
 #include "libgcl.h"
+#include "common.h"
 #include "hash.h"
 
 int GCL_Command_if_80020274(unsigned char *pScript)

--- a/src/libgcl/command.c
+++ b/src/libgcl/command.c
@@ -1,15 +1,15 @@
 #include "libgcl.h"
 #include "Game/game.h"
 
-GCL_COMMANDDEF *dword_800AB3B8 = 0;
+GCL_COMMANDDEF *commdef_800AB3B8 = 0;
 
-int GCL_AddCommMulti_8001FD2C(GCL_COMMANDDEF *pChain)
+int GCL_AddCommMulti_8001FD2C(GCL_COMMANDDEF *def)
 {
     // Set the new chains next to the existing chain
-    pChain->next = dword_800AB3B8;
+    def->next = commdef_800AB3B8;
 
     // Update the existing chain to be the new chain
-    dword_800AB3B8 = pChain;
+    commdef_800AB3B8 = def;
 
     return 0;
 }
@@ -20,7 +20,7 @@ GCL_COMMANDLIST *GCL_FindCommand_8001FD40(int hashedName)
     int              commandCount;
     GCL_COMMANDDEF  *pChainIter;
 
-    for (pChainIter = dword_800AB3B8; pChainIter; pChainIter = pChainIter->next)
+    for (pChainIter = commdef_800AB3B8; pChainIter; pChainIter = pChainIter->next)
     {
         pTableIter = pChainIter->commlist;
         for (commandCount = pChainIter->n_commlist; 0 < commandCount; commandCount--)

--- a/src/libgcl/libgcl.h
+++ b/src/libgcl/libgcl.h
@@ -229,7 +229,7 @@ enum GCLOperators
 #define GCLCODE_SHORT 1
 #define GCLCODE_BYTE 2
 #define GCLCODE_CHAR 3
-#define GCLCODE_BOOL 4
+#define GCLCODE_FLAG 4 // boolean
 #define GCLCODE_HASHED_STRING 6 // can also be a hashed proc name
 #define GCLCODE_STRING 7
 #define GCLCODE_PROC_CALL 8 // hashed proc name to call
@@ -250,7 +250,7 @@ enum GCLOperators
 #define GCL_GetVarTypeCode(gcl_var) (((gcl_var << 1) >> 25) & 0xF)
 #define GCL_GetVarOffset(gcl_var) (gcl_var & 0xFFFF)
 #define GCL_IsGameStateVar(gcl_var) ((gcl_var & 0xF00000) == 0x800000)
-#define GCL_GetBoolVarBitFlag(gcl_var) (char)(1 << (((gcl_var << 1) >> 17) & 0xF))
+#define GCL_GetFlagBitFlag(gcl_var) (char)(1 << (((gcl_var << 1) >> 17) & 0xF))
 #define GCL_StrHash(hash) ((GCLCODE_HASHED_STRING << 16) | (hash))
 
 static inline long GCL_GetLong(char *ptr) // leak

--- a/src/libgcl/libgcl.h
+++ b/src/libgcl/libgcl.h
@@ -102,7 +102,7 @@ typedef struct SaveGame
     int                f014_padding[3];
     char               f020_stageName[16];
     AreaHistory        f030_areaHistory;
-    short              f040_gameState[0x60];
+    short              f040_varbuf[0x60];
     GCL_Vars           f100_gcl_vars;
     RadioMemory        f900_radio_memory[RADIO_MEMORY_COUNT];
 } SaveGame; // size 0xA38

--- a/src/libgcl/parse.c
+++ b/src/libgcl/parse.c
@@ -61,7 +61,7 @@ unsigned char *GCL_GetNextValue_8002069C(unsigned char *pScript, int *retCode, i
 
     case GCLCODE_BYTE:
     case GCLCODE_CHAR:
-    case GCLCODE_BOOL:
+    case GCLCODE_FLAG:
         *retValue = (unsigned char)GCL_GetByte(ptr);
         ptr += 1;
         break;

--- a/src/libgcl/variable.c
+++ b/src/libgcl/variable.c
@@ -216,8 +216,8 @@ unsigned char *GCL_GetVar_80021634(unsigned char *pScript, int *retCode, int *re
         *retValue = (unsigned char)*ptr;
         break;
 
-    case GCLCODE_BOOL: // $f:
-        *retValue = (*ptr & GCL_GetBoolVarBitFlag(gcl_var)) != 0;
+    case GCLCODE_FLAG: // $f:
+        *retValue = (*ptr & GCL_GetFlagBitFlag(gcl_var)) != 0;
         break;
 
     default:
@@ -256,8 +256,8 @@ unsigned char *GCL_SetVar_8002171C(unsigned char *pScript, unsigned int value)
         *ptr = value;
         break;
 
-    case GCLCODE_BOOL:
-        bitFlag = GCL_GetBoolVarBitFlag(gcl_var);
+    case GCLCODE_FLAG:
+        bitFlag = GCL_GetFlagBitFlag(gcl_var);
         if (value)
         {
             *ptr |= bitFlag;
@@ -305,8 +305,8 @@ unsigned char *GCL_VarSaveBuffer_800217F0(unsigned char *pScript)
         *ptr = (char)value;
         break;
 
-    case GCLCODE_BOOL: // $f:
-        bitFlag = GCL_GetBoolVarBitFlag(gcl_var);
+    case GCLCODE_FLAG: // $f:
+        bitFlag = GCL_GetFlagBitFlag(gcl_var);
         if (value)
         {
             *ptr |= bitFlag;

--- a/src/libgcl/variable.c
+++ b/src/libgcl/variable.c
@@ -2,14 +2,14 @@
 #include "Game/game.h"
 #include "Game/linkvarbuf.h"
 
-extern short gGcl_gameStateVars_800B44C8[0x60];
+extern short sv_linkvarbuf_800B44C8[0x60];
 
 void GCL_SaveLinkVar_80020B90(short *gameVar)
 {
     char *addr;
     int   offset;
 
-    addr = (char *)gGcl_gameStateVars_800B44C8;
+    addr = (char *)sv_linkvarbuf_800B44C8;
     offset = (char *)gameVar - (char *)linkvarbuf;
     *(short *)(addr + offset) = *gameVar;
 }
@@ -56,7 +56,7 @@ extern RadioMemory gRadioMemory_800BDB38[RADIO_MEMORY_COUNT];
 
 extern char gStageName_800B4D88[16];
 
-extern short gGcl_gameStateVars_800B44C8[0x60];
+extern short sv_linkvarbuf_800B44C8[0x60];
 
 int GCL_MakeSaveFile_80020C0C(char *saveBuf)
 {
@@ -76,9 +76,9 @@ int GCL_MakeSaveFile_80020C0C(char *saveBuf)
 
     GM_LastSaveHours = GM_TotalHours;
     GM_LastSaveSeconds = GM_TotalSeconds;
-    GM_LinkVar(gGcl_gameStateVars_800B44C8, GM_LastSaveHours) = GM_TotalHours;
-    GM_LinkVar(gGcl_gameStateVars_800B44C8, GM_LastSaveSeconds) = GM_TotalSeconds;
-    GM_LinkVar(gGcl_gameStateVars_800B44C8, GM_TotalSaves) = GM_TotalSaves;
+    GM_LinkVar(sv_linkvarbuf_800B44C8, GM_LastSaveHours) = GM_TotalHours;
+    GM_LinkVar(sv_linkvarbuf_800B44C8, GM_LastSaveSeconds) = GM_TotalSeconds;
+    GM_LinkVar(sv_linkvarbuf_800B44C8, GM_TotalSaves) = GM_TotalSaves;
 
     save->f014_padding[0] = 0;
     save->f014_padding[1] = 0;
@@ -87,7 +87,7 @@ int GCL_MakeSaveFile_80020C0C(char *saveBuf)
     strcpy(save->f020_stageName, gStageName_800B4D88);
     GM_GetAreaHistory_8002A730(&save->f030_areaHistory);
 
-    memcpy(save->f040_gameState, gGcl_gameStateVars_800B44C8, 0xC0);
+    memcpy(save->f040_varbuf, sv_linkvarbuf_800B44C8, 0xC0);
     save->f100_gcl_vars = gGcl_memVars_800b4588;
     *(RdMem *)&save->f900_radio_memory = *(RdMem *)&gRadioMemory_800BDB38;
 
@@ -126,9 +126,9 @@ int GCL_SetLoadFile_80020EAC(char *saveBuf)
     strcpy(gStageName_800B4D88, save->f020_stageName);
     GM_SetAreaHistory_8002A784(&save->f030_areaHistory);
 
-    memcpy(gGcl_gameStateVars_800B44C8, save->f040_gameState, 0xC0);
+    memcpy(sv_linkvarbuf_800B44C8, save->f040_varbuf, 0xC0);
     gGcl_memVars_800b4588 = save->f100_gcl_vars;
-    memcpy(linkvarbuf, save->f040_gameState, 0xC0);
+    memcpy(linkvarbuf, save->f040_varbuf, 0xC0);
     gGcl_vars_800B3CC8 = save->f100_gcl_vars;
     *(RdMem *)&gRadioMemory_800BDB38 = *(RdMem *)&save->f900_radio_memory;
 
@@ -157,14 +157,14 @@ void GCL_InitClearVar_800212CC()
 
 void GCL_SaveVar_80021314(void)
 {
-    memcpy(gGcl_gameStateVars_800B44C8, linkvarbuf, 0xC0);
+    memcpy(sv_linkvarbuf_800B44C8, linkvarbuf, 0xC0);
     gGcl_memVars_800b4588 = gGcl_vars_800B3CC8;
     strcpy(gStageName_800B4D88, GM_GetArea_8002A880(0));
 }
 
 void GCL_RestoreVar_80021488(void)
 {
-    memcpy(linkvarbuf, gGcl_gameStateVars_800B44C8, 0x9C);
+    memcpy(linkvarbuf, sv_linkvarbuf_800B44C8, 0x9C);
     gGcl_vars_800B3CC8 = gGcl_memVars_800b4588;
 
     GM_SetArea_8002A7D8(GV_StrCode_80016CCC(gStageName_800B4D88), gStageName_800B4D88);
@@ -285,7 +285,7 @@ unsigned char *GCL_VarSaveBuffer_800217F0(unsigned char *pScript)
     gcl_code = GCL_GetVarTypeCode(gcl_var);
     if (GCL_IsGameStateVar(gcl_var))
     {
-        ptr = (char *)gGcl_gameStateVars_800B44C8;
+        ptr = (char *)sv_linkvarbuf_800B44C8;
     }
     else
     {

--- a/src/libgv/strcode.c
+++ b/src/libgv/strcode.c
@@ -8,7 +8,7 @@ int GV_StrCode_80016CCC(const char *string)
 
     while ((c = *p++))
     {
-        id = ((id >> 11) | (id << 5));
+        id = ((id << 5) | (id >> 11));
         id += c;
     }
     return id;

--- a/src/linker.h
+++ b/src/linker.h
@@ -3,8 +3,6 @@
 
 #define SECTION(x) __attribute__((section(x)))
 
-#define COUNTOF(x) sizeof(x) / sizeof(x[0])
-
 #define CTASTR2(pre, post) pre##post
 #define CTASTR(pre, post) CTASTR2(pre, post)
 #define STATIC_ASSERT(cond, msg, line)                                                                                 \

--- a/src/overlays/change/Onoda/change/safety.c
+++ b/src/overlays/change/Onoda/change/safety.c
@@ -2,7 +2,7 @@
 #include "libfs/libfs.h"
 #include "libgcl/libgcl.h"
 
-extern FS_FILE_INFO_8009D49C gDirFiles_8009D49C[];
+extern FS_FILE_INFO fs_file_info_8009D49C[];
 
 int SafetyCheck( int, int, int );
 
@@ -64,7 +64,7 @@ void Safety_800C4714( void )
 
 void Safety_800C476C( int timeout )
 {
-    Safety_800C45F8( gDirFiles_8009D49C[0].field_4_sector, timeout );
+    Safety_800C45F8( fs_file_info_8009D49C[0].sector, timeout );
     Safety_800C4714();
 }
 

--- a/src/overlays/s00a/Takabe/wt_view.c
+++ b/src/overlays/s00a/Takabe/wt_view.c
@@ -2,10 +2,23 @@
 #include "libgcl/libgcl.h"
 #include "libgv/libgv.h"
 
+// XXX SetPriority & DR_PRIO are undocumented APIs.
+// XXX They were previously public until their removal from libgpu.h
+// XXX in Runtime Library Release 3.7 (built December 27, 1996).
+
+// clang-format off
+typedef struct {
+        u_long  tag;
+        u_long  code[2];
+} DR_PRIO;                              /* Priority */
+
+extern void SetPriority(DR_PRIO *p, int pbc, int pbw);
+// clang-format on
+
 typedef struct _WaterViewPrims
 {
     DR_TPAGE tpage[4];
-    char     priority[2][12];
+    DR_PRIO  priority[2];
     SPRT     sprt[2][122];
     SPRT     sprt2[2][122];
     TILE     tile[4];
@@ -28,9 +41,6 @@ typedef struct _WaterViewWork
 extern int     GV_Clock_800AB920;
 extern int     GV_PauseLevel_800AB928;
 extern DG_CHNL DG_Chanls_800B1800[3];
-
-// TODO: can't find the signature of this function in PsyQ headers
-void SetPriority(void *prim, int, int);
 
 int  WaterViewCreatePrims_800DBEB8(WaterViewWork *work);
 void WaterViewInitSinTable_800DC0CC(void);
@@ -147,7 +157,7 @@ void WaterViewAct_800DB9E8(WaterViewWork *work)
         tile = &work->prims->tile2[GV_Clock_800AB920];
         addPrim(&ot[0xFF], tile);
 
-        priority = work->prims->priority[GV_Clock_800AB920];
+        priority = &work->prims->priority[GV_Clock_800AB920];
         SetPriority(priority, 0, 1);
         addPrim(&ot[0xFF], priority);
 

--- a/src/overlays/s03a/overlay.c
+++ b/src/overlays/s03a/overlay.c
@@ -41,7 +41,7 @@ GCL_ActorTableEntry s03aOverlayCharas[] =
     { CHARA_DYNAMIC_SEGMENT, NewDymcSeg_800C4BCC },
     { CHARA_LAMP, NewLamp_800C3B34 },
     { CHARA_MOSAIC, NewMosaic_800DCABC },
-    { CHARA_GUNCAME, NewGunCamE_800C9190 },
+    { CHARA_GUNCAME, NewGunCame_800C9190 },
     { CHARA_FADE_IN_OUT, NewFadeIo_800C42BC },
     { CHARA_GAS_EFFECT, NewGasEffect_800C4E5C },
     { CHARA_HIYOKO, NewHiyoko_800D018C },

--- a/src/overlays/s03e/Okajima/guncame.c
+++ b/src/overlays/s03e/Okajima/guncame.c
@@ -7,8 +7,8 @@
 #include "Game/object.h"
 #include "guncame.h"
 
-// We came, we saw, GunCamE
-typedef struct GunCamEWork
+// We came, we saw, GunCame
+typedef struct GunCameWork
 {
     GV_ACT   actor;
     CONTROL  control;
@@ -71,7 +71,7 @@ typedef struct GunCamEWork
     int      field_410;
     int      field_414;
     int      field_418;
-} GunCamEWork;
+} GunCameWork;
 
 int s03e_dword_800C32B4 = 0x00000000;
 int s03e_dword_800C32B8 = 0x00000000;
@@ -110,7 +110,7 @@ GV_ACT * NewSpark2_800CA714(MATRIX *world);
 GV_ACT * NewBulletEx_80076708(int, MATRIX *, int, int, int, int, int, int, int);
 
 // Identical to d03a_red_alrt_800C437C
-int GunCamE_800C6F60(unsigned short name, int nhashes, unsigned short *hashes)
+int GunCame_800C6F60(unsigned short name, int nhashes, unsigned short *hashes)
 {
     GV_MSG *msg;
     int     nmsgs;
@@ -137,7 +137,7 @@ int GunCamE_800C6F60(unsigned short name, int nhashes, unsigned short *hashes)
     return found;
 }
 
-void GunCamE_800C6FF8(GunCamEWork *work)
+void GunCame_800C6FF8(GunCameWork *work)
 {
     SVECTOR svec;
 
@@ -150,7 +150,7 @@ void GunCamE_800C6FF8(GunCamEWork *work)
     work->field_338 = svec;
 }
 
-void GunCamE_800C7068(GunCamEWork *work)
+void GunCame_800C7068(GunCameWork *work)
 {
     work->field_3A0 = 1;
     work->field_3AC[0] = GM_PlayerPosition_800ABA10;
@@ -169,7 +169,7 @@ void GunCamE_800C7068(GunCamEWork *work)
     }
 }
 
-void GunCamE_800C7118(DG_PRIM *prim, DG_TEX *tex, int r, int g, int b)
+void GunCame_800C7118(DG_PRIM *prim, DG_TEX *tex, int r, int g, int b)
 {
     POLY_FT4 *poly;
 
@@ -180,14 +180,14 @@ void GunCamE_800C7118(DG_PRIM *prim, DG_TEX *tex, int r, int g, int b)
     setRGB0(poly, r, g, b);
 }
 
-void GunCamE_800C7144(GunCamEWork *work, int r, int g, int b)
+void GunCame_800C7144(GunCameWork *work, int r, int g, int b)
 {
     work->field_3F4.vx = r;
     work->field_3F4.vy = g;
     work->field_3F4.vz = b;
 }
 
-int GunCamE_800C7154(char *opt, SVECTOR *svec)
+int GunCame_800C7154(char *opt, SVECTOR *svec)
 {
     int   count;
     char *result;
@@ -205,7 +205,7 @@ int GunCamE_800C7154(char *opt, SVECTOR *svec)
     return count;
 }
 
-void GunCamE_800C71A8(SVECTOR* arg0, SVECTOR* arg1, SVECTOR* arg2) {
+void GunCame_800C71A8(SVECTOR* arg0, SVECTOR* arg1, SVECTOR* arg2) {
 
     SVECTOR sp10;
     int temp_s0;
@@ -220,7 +220,7 @@ void GunCamE_800C71A8(SVECTOR* arg0, SVECTOR* arg1, SVECTOR* arg2) {
     arg2->vx = (short int) ((ratan2(GV_VecLen3_80016D80(&sp10), (int) temp_s0) & 0xFFF) - 0x400);
 }
 
-int GunCamE_800C7224(GunCamEWork *work)
+int GunCame_800C7224(GunCameWork *work)
 {
     SVECTOR  ang;
     CONTROL *control;
@@ -262,7 +262,7 @@ int GunCamE_800C7224(GunCamEWork *work)
         {
             success = 0;
 
-            GunCamE_800C71A8(&work->control.mov, &work->field_3AC[index], &ang);
+            GunCame_800C71A8(&work->control.mov, &work->field_3AC[index], &ang);
 
             dy = GV_DiffDirAbs_8001706C(ang.vy, work->control.rot.vy);
             dx = GV_DiffDirAbs_8001706C(ang.vx, work->control.rot.vx);
@@ -288,14 +288,14 @@ int GunCamE_800C7224(GunCamEWork *work)
     return 0;
 }
 
-void GunCamE_800C73D0(GunCamEWork *work)
+void GunCame_800C73D0(GunCameWork *work)
 {
     MATRIX pos;
     int    f3C4;
 
     dword_8009F480 = 0;
 
-    GunCamE_800C6FF8(work);
+    GunCame_800C6FF8(work);
 
     if ((work->field_3C4 == 0) && ((work->field_39C > 0) && (work->field_39C < 3)))
     {
@@ -308,7 +308,7 @@ void GunCamE_800C73D0(GunCamEWork *work)
     f3C4 = work->field_3C4;
     if (f3C4 == 1)
     {
-        if ((--work->field_3C8 == 0) && GunCamE_800C7224(work))
+        if ((--work->field_3C8 == 0) && GunCame_800C7224(work))
         {
             dword_8009F480 = f3C4;
         }
@@ -356,7 +356,7 @@ void GunCamE_800C73D0(GunCamEWork *work)
 
 const SVECTOR s03e_svec_800CC084 = {0, -80, 0, 0};
 
-void GunCamE_800C75FC(SVECTOR *svec1, SVECTOR *svec2, GunCamEWork *work)
+void GunCame_800C75FC(SVECTOR *svec1, SVECTOR *svec2, GunCameWork *work)
 {
     int dir;
 
@@ -381,13 +381,13 @@ void GunCamE_800C75FC(SVECTOR *svec1, SVECTOR *svec2, GunCamEWork *work)
     }
 }
 
-void GunCamE_800C76E8(GunCamEWork* work)
+void GunCame_800C76E8(GunCameWork* work)
 {
-    GunCamE_800C71A8(&work->control.mov, &work->field_3AC[work->field_39C], &work->control.turn);
-    GunCamE_800C75FC(&work->field_330, &work->control.turn, work);
+    GunCame_800C71A8(&work->control.mov, &work->field_3AC[work->field_39C], &work->control.turn);
+    GunCame_800C75FC(&work->field_330, &work->control.turn, work);
 }
 
-int GunCamE_800C7740(GunCamEWork *work)
+int GunCame_800C7740(GunCameWork *work)
 {
     SVECTOR *vec;
 
@@ -410,7 +410,7 @@ int GunCamE_800C7740(GunCamEWork *work)
     return 0;
 }
 
-int GunCamE_800C77D4(GunCamEWork *work)
+int GunCame_800C77D4(GunCameWork *work)
 {
     SVECTOR *vec;
 
@@ -433,7 +433,7 @@ int GunCamE_800C77D4(GunCamEWork *work)
     return 0;
 }
 
-int GunCamE_800C7868(GunCamEWork *work)
+int GunCame_800C7868(GunCameWork *work)
 {
     SVECTOR *svec1, *svec2;
     int      dir;
@@ -478,12 +478,12 @@ int GunCamE_800C7868(GunCamEWork *work)
     return 1;
 }
 
-void GunCamE_800C7994(GunCamEWork *work)
+void GunCame_800C7994(GunCameWork *work)
 {
     switch (work->field_344)
     {
     case 2:
-        if (GunCamE_800C7740(work))
+        if (GunCame_800C7740(work))
         {
             work->field_344 = 3;
             work->field_34C = GV_RandU_80017090(32);
@@ -492,7 +492,7 @@ void GunCamE_800C7994(GunCamEWork *work)
         break;
 
     case 3:
-        if (GunCamE_800C77D4(work))
+        if (GunCame_800C77D4(work))
         {
             work->field_344 = 2;
             work->field_34C = GV_RandU_80017090(32);
@@ -505,7 +505,7 @@ void GunCamE_800C7994(GunCamEWork *work)
         break;
     }
 
-    if ((((GV_Time_800AB330 + work->field_414) & 3) == 0) && GunCamE_800C7224(work))
+    if ((((GV_Time_800AB330 + work->field_414) & 3) == 0) && GunCame_800C7224(work))
     {
         AN_Unknown_800CA1EC(&work->field_9C.objs->objs[0].world, 0);
 
@@ -523,25 +523,25 @@ void GunCamE_800C7994(GunCamEWork *work)
         work->field_344 = 5;
         work->field_34C = 0;
 
-        GunCamE_800C7144(work, 0xFF, 0, 0);
+        GunCame_800C7144(work, 0xFF, 0, 0);
 
         work->field_3EC = 10;
     }
 }
 
-void GunCamE_800C7AD8(GunCamEWork *work)
+void GunCame_800C7AD8(GunCameWork *work)
 {
     switch (work->field_344)
     {
     case 5:
-        GunCamE_800C76E8(work);
+        GunCame_800C76E8(work);
         work->field_348++;
         if (!(work->field_348 & 3))
         {
             if (work->field_354 < work->field_370)
             {
                 work->field_354++;
-                GunCamE_800C73D0(work);
+                GunCame_800C73D0(work);
                 if (work->field_404 != 0)
                 {
                     GM_Sound_800329C4(&work->control.mov, 0x2E, 1);
@@ -562,7 +562,7 @@ void GunCamE_800C7AD8(GunCamEWork *work)
         {
             work->field_350 = 0;
         }
-        if (GunCamE_800C7224(work) == 0)
+        if (GunCame_800C7224(work) == 0)
         {
             work->field_344 = 1;
             work->field_34C = 0;
@@ -579,7 +579,7 @@ void GunCamE_800C7AD8(GunCamEWork *work)
             work->field_34C = 0;
             break;
         }
-        if (GunCamE_800C7224(work) != 0)
+        if (GunCame_800C7224(work) != 0)
         {
             work->field_344 = 5;
         }
@@ -587,7 +587,7 @@ void GunCamE_800C7AD8(GunCamEWork *work)
     }
 }
 
-void GunCamE_800C7C0C(GunCamEWork *work)
+void GunCame_800C7C0C(GunCameWork *work)
 {
     switch (work->field_344)
     {
@@ -595,7 +595,7 @@ void GunCamE_800C7C0C(GunCamEWork *work)
         work->field_344 = 7;
         break;
     case 7:
-        if (GunCamE_800C7868(work) != 0)
+        if (GunCame_800C7868(work) != 0)
         {
             work->field_340 = 0;
             if (work->field_360 == 1)
@@ -614,21 +614,21 @@ void GunCamE_800C7C0C(GunCamEWork *work)
                 work->field_344 = 4;
             }
             work->field_34C = 0;
-            GunCamE_800C7144(work, 0, 0xFF, 0);
+            GunCame_800C7144(work, 0, 0xFF, 0);
         }
         break;
     }
 
-    if (GunCamE_800C7224(work) != 0)
+    if (GunCame_800C7224(work) != 0)
     {
         work->field_340 = 1;
         work->field_344 = 5;
         work->field_34C = 0;
-        GunCamE_800C7144(work, 0xFF, 0, 0);
+        GunCame_800C7144(work, 0xFF, 0, 0);
     }
 }
 
-void GunCamE_800C7CE0(GunCamEWork *work)
+void GunCame_800C7CE0(GunCameWork *work)
 {
     int time;
     int tx, ty;
@@ -658,18 +658,18 @@ void GunCamE_800C7CE0(GunCamEWork *work)
             work->control.turn.vx &= 0xFFF;
             work->control.turn.vy &= 0xFFF;
 
-            GunCamE_800C75FC(&work->field_330, &work->control.turn, work);
+            GunCame_800C75FC(&work->field_330, &work->control.turn, work);
 
             // Each macro expansion calls rsin three times
             work->field_3FC.vx = ABS(rsin(time * 95) / 16);
             work->field_3FC.vy = ABS(rsin(time * 154) / 16);
             work->field_3FC.vz = ABS(rsin(time * 43) / 16);
 
-            GunCamE_800C7144(work, work->field_3FC.vx, work->field_3FC.vy, work->field_3FC.vz);
+            GunCame_800C7144(work, work->field_3FC.vx, work->field_3FC.vy, work->field_3FC.vz);
         }
         else
         {
-            GunCamE_800C7144(work, 0, 255, 0);
+            GunCame_800C7144(work, 0, 255, 0);
 
             work->field_3D0 = -1;
             work->field_340 = 2;
@@ -680,35 +680,35 @@ void GunCamE_800C7CE0(GunCamEWork *work)
     }
 }
 
-void GunCamE_800C8024(GunCamEWork *work)
+void GunCame_800C8024(GunCameWork *work)
 {
     work->control.radar_cone.dir = work->control.rot.vy;
 }
 
-void GunCamE_800C8030(GunCamEWork *work)
+void GunCame_800C8030(GunCameWork *work)
 {
     switch (work->field_340)
     {
     case 0:
         GM_ConfigControlInterp_80026244(&work->control, 4);
-        GunCamE_800C7994(work);
+        GunCame_800C7994(work);
         break;
     case 1:
         GM_ConfigControlInterp_80026244(&work->control, 0);
-        GunCamE_800C7AD8(work);
+        GunCame_800C7AD8(work);
         break;
     case 2:
         GM_ConfigControlInterp_80026244(&work->control, 4);
-        GunCamE_800C7C0C(work);
+        GunCame_800C7C0C(work);
         break;
     case 3:
         GM_ConfigControlInterp_80026244(&work->control, 4);
-        GunCamE_800C7CE0(work);
+        GunCame_800C7CE0(work);
         break;
     }
 }
 
-void GunCamE_Act_800C80F4(GunCamEWork *work)
+void GunCame_Act_800C80F4(GunCameWork *work)
 {
     MATRIX         world;
     SVECTOR        rot;
@@ -737,7 +737,7 @@ void GunCamE_Act_800C80F4(GunCamEWork *work)
     hashes[5] = GV_StrCode_80016CCC("処理再開");
     hashes[6] = GV_StrCode_80016CCC("処理停止");
 
-    found = GunCamE_800C6F60(work->name, 7, hashes);
+    found = GunCame_800C6F60(work->name, 7, hashes);
     switch(found)
     {
     case 0:
@@ -799,8 +799,8 @@ void GunCamE_Act_800C80F4(GunCamEWork *work)
     work->field_3FC.vy = (work->field_3FC.vy * 15 + work->field_3F4.vy) / 16;
     work->field_3FC.vz = (work->field_3FC.vz * 15 + work->field_3F4.vz) / 16;
 
-    GunCamE_800C7118(work->field_328, work->field_32C, work->field_3FC.vx, work->field_3FC.vy, work->field_3FC.vz);
-    GunCamE_800C7068(work);
+    GunCame_800C7118(work->field_328, work->field_32C, work->field_3FC.vx, work->field_3FC.vy, work->field_3FC.vz);
+    GunCame_800C7068(work);
 
     if (work->field_3EC > 0)
     {
@@ -845,7 +845,7 @@ void GunCamE_Act_800C80F4(GunCamEWork *work)
     }
     else
     {
-        GunCamE_800C7144(work, 0, 255, 0);
+        GunCame_800C7144(work, 0, 255, 0);
 
         work->field_3D0 = -1;
         work->field_340 = 2;
@@ -967,7 +967,7 @@ void GunCamE_Act_800C80F4(GunCamEWork *work)
         DG_InvisibleObjs(work->field_9C.objs);
         DG_InvisibleObjs(work->field_1F4.objs);
 
-        GunCamE_800C7144(work, 0, 0, 0);
+        GunCame_800C7144(work, 0, 0, 0);
 
         if ((work->field_35C >= 20) || ((s03e_dword_800C32BC & 0x1) == 0))
         {
@@ -993,11 +993,11 @@ void GunCamE_Act_800C80F4(GunCamEWork *work)
         }
     }
 
-    GunCamE_800C8024(work);
-    GunCamE_800C8030(work);
+    GunCame_800C8024(work);
+    GunCame_800C8030(work);
 }
 
-void GunCamE_800C8940(GunCamEWork *work)
+void GunCame_800C8940(GunCameWork *work)
 {
     CONTROL    *control;
     RADAR_CONE *cone;
@@ -1014,7 +1014,7 @@ void GunCamE_800C8940(GunCamEWork *work)
 
 const SVECTOR s03e_svec_800CC0F4 = {0, -150, -400, 0};
 
-int GunCamE_800C8978(GunCamEWork *work, int name, int map)
+int GunCame_800C8978(GunCameWork *work, int name, int map)
 {
     SVECTOR disp_local;
     SVECTOR pos;
@@ -1063,7 +1063,7 @@ int GunCamE_800C8978(GunCamEWork *work, int name, int map)
     opt = GCL_GetOption_80020968('p');
     if (opt != NULL)
     {
-        GunCamE_800C7154(opt, &pos);
+        GunCame_800C7154(opt, &pos);
     }
     else
     {
@@ -1073,7 +1073,7 @@ int GunCamE_800C8978(GunCamEWork *work, int name, int map)
     opt = GCL_GetOption_80020968('d');
     if (opt != NULL)
     {
-        GunCamE_800C7154(opt, &dir);
+        GunCame_800C7154(opt, &dir);
     }
     else
     {
@@ -1096,7 +1096,7 @@ int GunCamE_800C8978(GunCamEWork *work, int name, int map)
     opt = GCL_GetOption_80020968('r');
     if (opt != NULL)
     {
-        GunCamE_800C7154(opt, &pos);
+        GunCame_800C7154(opt, &pos);
         work->control.turn.vx += pos.vx;
         work->control.turn.vy += pos.vy;
     }
@@ -1177,7 +1177,7 @@ int GunCamE_800C8978(GunCamEWork *work, int name, int map)
     {
         work->field_3F0 = 1;
         GM_ConfigControlAttribute_8002623C(&work->control, 0x47);
-        GunCamE_800C8940(work);
+        GunCame_800C8940(work);
     }
 
     opt = GCL_GetOption_80020968('o');
@@ -1243,7 +1243,7 @@ int GunCamE_800C8978(GunCamEWork *work, int name, int map)
     return 0;
 }
 
-void GunCamE_800C8E04(POLY_FT4 *poly, DG_TEX *tex, int col)
+void GunCame_800C8E04(POLY_FT4 *poly, DG_TEX *tex, int col)
 {
     char height;
     char width;
@@ -1273,7 +1273,7 @@ void GunCamE_800C8E04(POLY_FT4 *poly, DG_TEX *tex, int col)
     poly->clut = (unsigned short) tex->clut;
 }
 
-int GunCamE_800C8E7C(GunCamEWork *work)
+int GunCame_800C8E7C(GunCameWork *work)
 {
     DG_PRIM *prim;
     DG_TEX  *tex;
@@ -1290,15 +1290,15 @@ int GunCamE_800C8E7C(GunCamEWork *work)
         work->field_32C = tex;
         if (tex != 0)
         {
-            GunCamE_800C8E04(&prim->packs[0]->poly_ft4, tex, 128);
-            GunCamE_800C8E04(&prim->packs[1]->poly_ft4, tex, 100);
+            GunCame_800C8E04(&prim->packs[0]->poly_ft4, tex, 128);
+            GunCame_800C8E04(&prim->packs[1]->poly_ft4, tex, 100);
             return 0;
         }
     }
     return -1;
 }
 
-int GunCamE_GetResources_800C8F64(GunCamEWork *work, int name, int where)
+int GunCame_GetResources_800C8F64(GunCameWork *work, int name, int where)
 {
     CONTROL *control;
     OBJECT  *obj1, *obj2;
@@ -1328,7 +1328,7 @@ int GunCamE_GetResources_800C8F64(GunCamEWork *work, int name, int where)
     GM_InitObject_80034A18(obj2, GV_StrCode_80016CCC("gca_arm"), 0x26D, 0);
     GM_ConfigObjectLight_80034C44(obj2, work->field_2D8);
 
-    if (GunCamE_800C8E7C(work) == -1)
+    if (GunCame_800C8E7C(work) == -1)
     {
         return -1;
     }
@@ -1337,7 +1337,7 @@ int GunCamE_GetResources_800C8F64(GunCamEWork *work, int name, int where)
     if (work->target)
     {
         GM_SetTarget_8002DC74(work->target, 0x15, 2, &guncame_svec);
-        GunCamE_800C8978(work, name, where);
+        GunCame_800C8978(work, name, where);
         DG_GetLightMatrix_8001A3C4(&control->mov, work->field_180);
         DG_GetLightMatrix_8001A3C4(&control->mov, work->field_2D8);
         s03e_dword_800CC6BC = 0;
@@ -1350,7 +1350,7 @@ int GunCamE_GetResources_800C8F64(GunCamEWork *work, int name, int where)
     return -1;
 }
 
-void GunCamE_Die_800C911C(GunCamEWork *work)
+void GunCame_Die_800C911C(GunCameWork *work)
 {
     DG_PRIM *prim;
 
@@ -1368,16 +1368,16 @@ void GunCamE_Die_800C911C(GunCamEWork *work)
     }
 }
 
-GV_ACT *NewGunCamE_800C9190(int name, int where, int argc, char **argv)
+GV_ACT *NewGunCame_800C9190(int name, int where, int argc, char **argv)
 {
-    GunCamEWork *work;
+    GunCameWork *work;
 
-    work = (GunCamEWork *)GV_NewActor_800150E4(4, sizeof(GunCamEWork));
+    work = (GunCameWork *)GV_NewActor_800150E4(4, sizeof(GunCameWork));
     if (work != NULL)
     {
-        GV_SetNamedActor_8001514C(&work->actor, (TActorFunction)GunCamE_Act_800C80F4,
-                                  (TActorFunction)GunCamE_Die_800C911C, "guncame.c");
-        if (GunCamE_GetResources_800C8F64(work, name, where) < 0)
+        GV_SetNamedActor_8001514C(&work->actor, (TActorFunction)GunCame_Act_800C80F4,
+                                  (TActorFunction)GunCame_Die_800C911C, "guncame.c");
+        if (GunCame_GetResources_800C8F64(work, name, where) < 0)
         {
             GV_DestroyActor_800151C8(&work->actor);
             return NULL;

--- a/src/overlays/s03e/Okajima/guncame.h
+++ b/src/overlays/s03e/Okajima/guncame.h
@@ -1,6 +1,6 @@
 #ifndef _GUNCAME_H_
 #define _GUNCAME_H_
 
-GV_ACT *NewGunCamE_800C9190(int name, int where, int argc, char **argv);
+GV_ACT *NewGunCame_800C9190(int name, int where, int argc, char **argv);
 
 #endif // _GUNCAME_H_

--- a/src/overlays/s03e/overlay.c
+++ b/src/overlays/s03e/overlay.c
@@ -20,7 +20,7 @@ GCL_ActorTableEntry s03eOverlayCharas[] =
     { CHARA_ELEVATOR_PANEL, NewEvPanel_800C4AD8 },
     { CHARA_UJI, NewUji_800C42F8 },
     { CHARA_LAMP, NewLamp_800C3B34 },
-    { CHARA_GUNCAME, NewGunCamE_800C9190 },
+    { CHARA_GUNCAME, NewGunCame_800C9190 },
     { CHARA_FADE_IN_OUT, NewFadeIo_800C42BC },
     { CHARA_INTR_CAM, NewIntrCam_800C5748 },
     { CHARA_CAT_IN, NewZoom_800DFA88 },

--- a/src/overlays/s12c/Takabe/libdg2.c
+++ b/src/overlays/s12c/Takabe/libdg2.c
@@ -1794,7 +1794,7 @@ void FogShadeChanl_800D6A04(DG_CHNL *channel, int index)
                         }
                         else
                         {
-                            SetSpadStack(0x1F8003FC);
+                            SetSpadStack(SPAD_STACK_ADDR);
                             s12c_800D6588(obj, index);
                             ResetSpadStack();
                             obj->bound_mode &= ~bound_index;


### PR DESCRIPTION
- Replaced the scratchpad macros as-written in stack.txt (seminar/advanced/source/graphics/gte/text) and summarized the given precautions in the above comment. I turned off clang formatting around the macros to signal the code is transplanted from an outside source. You can get rid of that if you want.
- Copied the SetPriority prototype & DR_PRIO struct definition from SDK 3.6's <libgpu.h> into Takabe/wt_view.c, changed the original 8-char tabs to spaces. clang-format off for the same reason.
- Created an .editorconfig file for consistency. Also helps intermediate asm output display correctly if your editor defaults to 4-char tabs.
- Moved COUNTOF macro to common.h since it makes more sense there (with min/max & friends) than in the header for setting compiler-specific attributes & static assertions.
- Reformatted SAFECHK.s to use tabs instead of a constant mix of tabs/spaces. Just like the pioneers used to write.
- Reorderd the shift operations in GV_StrCode to reflect MGS2's (24-bit) impl. where it **must** be written ``id = ((id << 5) | (id >> 19));`` to match. Boktai 2 also does the left shift **first** in the asm (see FUN_08230860 in https://github.com/akatsuki105/boktai2).