### PR TITLE
Improve stage selection menu in dev variant

### DIFF
--- a/build/linker_command_file.txt
+++ b/build/linker_command_file.txt
@@ -321,6 +321,7 @@
     include "{{OBJ_DIR}}\overlays\s16b\unknown.obj"
     include "{{OBJ_DIR}}\overlays\s16b\unknown2.obj"
     include "{{OBJ_DIR}}\overlays\s00a\Takabe\elevator.obj"
+    include "{{OBJ_DIR}}\overlays\s03e\Game\evpanel.obj"
     include "{{OBJ_DIR}}\overlays\s00a\Takabe\wt_area.obj"
     include "{{OBJ_DIR}}\overlays\s00a\Okajima\splash2.obj"
     include "{{OBJ_DIR}}\overlays\s00a\Takabe\wt_view.obj"

--- a/src/contrib/dev/overlay_table.c
+++ b/src/contrib/dev/overlay_table.c
@@ -26,6 +26,7 @@
 #include "overlays/s00a/Enemy/smoke.h"
 #include "overlays/s00a/Thing/emitter.h"
 #include "overlays/s00a/Takabe/elevator.h"
+#include "overlays/s03e/Game/evpanel.h"
 #include "overlays/s00a/Okajima/mouse.h"
 #include "overlays/s00a/Takabe/rsurface.h"
 #include "overlays/s00a/Takabe/telop.h"
@@ -71,6 +72,7 @@ GCL_ActorTableEntry devOverlayCharas[] =
     { CHARA_SMOKE, NewSmoke_800D2BEC },
     { CHARA_EMITTER, NewEmitter_800C3E50 },
     { CHARA_ELEVATOR, NewElevator_800D9F30 },
+    { CHARA_ELEVATOR_PANEL, NewEvPanel_800C4AD8 },
     { CHARA_MOUSE, NewMouse_800D5234 },
     { CHARA_RSURFACE, NewRippleSurface_800D8244 },
     { CHARA_TELOP, NewTelopSet_800DDB34 },

--- a/src/overlays/select1/Game/select.c
+++ b/src/overlays/select1/Game/select.c
@@ -1,6 +1,10 @@
 #include "select.h"
 #include "libgcl/libgcl.h"
 
+#ifdef DEV_EXE
+#include "psyq.h"
+#endif
+
 typedef struct Work
 {
     GV_ACT         actor;
@@ -21,6 +25,29 @@ extern GV_PAD GV_PadData_800B05C0[4];
 
 #define EXEC_LEVEL 3
 
+#ifdef DEV_EXE
+int isStageSelectionMenu; // Used to print the extended info below only in stage selection menu.
+char* extendedInfo[] = {
+    "%s [ %d ]", // TITLE
+    "%s: LOADING DOCK - CUTSCENE [ %d ]", // D00A
+    "%s: LOADING DOCK [ %d ]", // S00A
+    "%s: HELIPORT - CUTSCENE [ %d ]", // D01A
+    "%s: HELIPORT - USING SCOPE [ %d ]", // S01A
+    "%s: HELIPORT [ %d ]", // S01A1
+    "%s: TANK HANGAR [ %d ]", // S02A
+    "%s: TANK HANGAR 2 [ %d ]", // S02B
+    "%s: TANK HANGAR - BEFORE CONTACTING MERYL [ %d ]", // S02C
+    "%s: TANK HANGAR - AFTER CONTACTING MERYL [ %d ]", // S02D
+    "%s: TANK HANGAR - AFTER TORTURE [ %d ]", // S02E
+    "%s: HOLDING CELL [ %d ]", // S03A
+    "%s: MEDICAL ROOM [ %d ]", // S03B
+    "%s: MEDICAL ROOM 2 [ %d ]", // S03C
+    "%s: ARMORY [ %d ]", // S04A
+    "%s: ARMORY SOUTH - VS OCELOT [ %d ]", // S04B
+    "%s [ %d ]" // RETURN
+};
+#endif
+
 void SelectUpdateCurrentEntry_800C3218(Work *work, int dir)
 {
     int   i;
@@ -28,10 +55,22 @@ void SelectUpdateCurrentEntry_800C3218(Work *work, int dir)
     char *entry_name;
 
     work->current_idx += dir;
+#ifdef DEV_EXE
+    // Circular scrolling (only in stage selection menu to keep things simple).
+    if (work->current_idx < 0)
+    {
+        work->current_idx = isStageSelectionMenu ? 16 : 0;
+    }
+    else if (isStageSelectionMenu && work->current_idx > 16)
+    {
+        work->current_idx = 0;
+    }
+#else
     if (work->current_idx < 0)
     {
         work->current_idx = 0;
     }
+#endif 
 
     GCL_SetArgTop_80020690(work->gcl_menu_entries);
     for (i = 0; i <= work->current_idx; i++)
@@ -53,6 +92,9 @@ void SelectAct_800C32D8(Work *work)
 {
     int     dir;
     GV_PAD *pPad;
+#ifdef DEV_EXE
+    char stageInfo[55];
+#endif
 
     pPad = &GV_PadData_800B05C0[0];
 
@@ -89,7 +131,20 @@ void SelectAct_800C32D8(Work *work)
     }
     menu_Text_Init_80038B98();
     MENU_Locate_80038B34(160, 120, 2);
+
+#ifdef DEV_EXE
+    if (isStageSelectionMenu)
+    {
+        sprintf(stageInfo, extendedInfo[work->current_idx], work->current_entry_name, work->current_entry_proc_id);
+    }
+    else
+    {
+        strcpy(stageInfo, work->current_entry_name);
+    }
+    MENU_Printf_80038C38(stageInfo);
+#else
     MENU_Printf_80038C38(work->current_entry_name);
+#endif
 }
 
 int SelectGetResources_800C33D0(Work *work, int param_2, int param_3)
@@ -121,5 +176,10 @@ GV_ACT *NewSelect_800C3434(int name, int where, int argc, char **argv)
             return NULL;
         }
     }
+
+#ifdef DEV_EXE
+    isStageSelectionMenu = name == 10524;
+#endif
+
     return &work->actor;
 }


### PR DESCRIPTION
The dev variant is useful, but it is difficult to remember what "S01A" etc. refer to in the stage selection menu, so I added an extended description for each entry:

![image](https://github.com/user-attachments/assets/4c923837-f54e-4e45-bf59-8aefe6dd6241)

Also, the evpanel actor was added to avoid getting stuck in the elevator in some stages.
Finally, I made the selection menu circular-scrollable (a must for lazy people like me).