### PR TITLE
bakudan(C4): cleanup and documentation

### DIFF
--- a/src/Bullet/bakudan.c
+++ b/src/Bullet/bakudan.c
@@ -13,7 +13,7 @@ extern int     GM_GameStatus_800AB3CC;
 extern GV_PAD  GV_PadData_800B05C0[4];
 extern int     GM_PlayerStatus_800ABA50;
 
-extern HITTABLE stru_800BDD78[16];
+extern HITTABLE c4_actors[16];
 extern int GM_CurrentMap_800AB9B0;
 
 extern int GV_Time_800AB330;
@@ -25,10 +25,18 @@ extern SVECTOR GM_PlayerPosition_800ABA10;
 extern Blast_Data blast_data_8009F4B8[8];
 
 int bakudan_count_8009F42C = 0;
-int dword_8009F430 = 0;
-int dword_8009F434 = 0;
+int time_last_press_8009F430 = 0;
+int dword_8009F434 = 0; // unused variable
+
+// default orientation for c4 object when placed on a moving target
+// (probably to keep it upright because the 3d model is not oriented correctly)
 SVECTOR svector_8009F438 = {3072, 0, 0, 0};
 
+/**
+ * @brief Main function for the C4 actor. Handles the logic for the C4's behavior.
+ *
+ * @param work Pointer to the BakudanWork structure.
+ */
 void bakudan_act_8006A218(BakudanWork *work)
 {
     MATRIX rotation;
@@ -39,7 +47,7 @@ void bakudan_act_8006A218(BakudanWork *work)
 #ifdef VR_EXE
     int cond;
 #endif
-
+    // if invalid game status, destroy the actor
     if (GM_GameStatus_800AB3CC < 0)
     {
         GV_DestroyActor_800151C8(&work->actor);
@@ -54,17 +62,20 @@ void bakudan_act_8006A218(BakudanWork *work)
         pPad = &GV_PadData_800B05C0[1];
     }
 
-    work->field_110_pPad = pPad;
+    work->active_pad = pPad;
     GM_ActControl_80025A7C(pCtrl);
 
     pMtx = work->field_100_pMtx;
 
+    // if the c4 is placed on a moving target
     if (pMtx)
     {
         DG_RotatePos_8001BD64(&svector_8009F438);
-        pTarget = stru_800BDD78[work->field_114].data;
-        work->field_118 = pTarget->map;
+        // get the target where the c4 is placed
+        pTarget = c4_actors[work->c4_index].data;
+        work->map_index = pTarget->map;
 
+        // if the target is not alive, destroy the actor
         if (!pTarget->field_20)
         {
             GV_DestroyActor_800151C8(&work->actor);
@@ -72,7 +83,7 @@ void bakudan_act_8006A218(BakudanWork *work)
         }
     }
 
-    GM_CurrentMap_800AB9B0 = work->field_118;
+    GM_CurrentMap_800AB9B0 = work->map_index;
 
     GM_ActObject2_80034B88((OBJECT *)&work->field_9C_kmd);
     DG_GetLightMatrix_8001A3C4(&pCtrl->mov, work->field_C0_light_mtx);
@@ -82,12 +93,17 @@ void bakudan_act_8006A218(BakudanWork *work)
     // of the condition below to a temporary variable!?
     cond = 0;
 #endif
-    if (((work->field_110_pPad->press & PAD_CIRCLE) &&
-        (dword_8009F430 != GV_Time_800AB330) &&
-        (GM_CurrentMap_800AB9B0 & GM_PlayerMap_800ABA0C) &&
-        !(GM_GameStatus_800AB3CC & STATE_PADRELEASE) &&
-        !(GM_PlayerStatus_800ABA50 & PLAYER_PAD_OFF) &&
-        !(GM_ItemTypes_8009D598[GM_CurrentItemId + 1] & 2)) ||
+    // check if the circle button was pressed
+    // the frame counter is different from the last time the circle button was pressed to prevent counting multiple presses in the same frame
+    // the player is in the same map as the c4
+    // the player has not released the pad
+    // the player is not holding an item that can't be used with the c4
+    if (((work->active_pad->press & PAD_CIRCLE) &&
+         (time_last_press_8009F430 != GV_Time_800AB330) &&
+         (GM_CurrentMap_800AB9B0 & GM_PlayerMap_800ABA0C) &&
+         !(GM_GameStatus_800AB3CC & STATE_PADRELEASE) &&
+         !(GM_PlayerStatus_800ABA50 & PLAYER_PAD_OFF) &&
+         !(GM_ItemTypes_8009D598[GM_CurrentItemId + 1] & 2)) ||
         dword_8009F434)
 #ifdef VR_EXE
     {
@@ -96,22 +112,23 @@ void bakudan_act_8006A218(BakudanWork *work)
     if (cond)
 #endif
     {
-        work->field_108 = 1;
+        work->detonator_btn_pressed = 1;
 
-        if (work->field_110_pPad->press & PAD_CIRCLE)
+        if (work->active_pad->press & PAD_CIRCLE)
         {
             GM_SeSetMode_800329C4(&GM_PlayerPosition_800ABA10, 0x32, GM_SEMODE_BOMB);
         }
 
-        dword_8009F430 = GV_Time_800AB330;
+        time_last_press_8009F430 = GV_Time_800AB330;
     }
-
-    if (work->field_108)
+    // keep track of the consecutive frames the circle button is pressed
+    if (work->detonator_btn_pressed)
     {
-        work->field_10C++;
+        work->detonator_frames_count++;
     }
 
-    if (work->field_10C >= 3)
+    // detonate the c4 after 3 frames
+    if (work->detonator_frames_count >= 3)
     {
         ReadRotMatrix(&rotation);
         NewBlast_8006DFDC(&rotation, &blast_data_8009F4B8[1]);
@@ -120,31 +137,42 @@ void bakudan_act_8006A218(BakudanWork *work)
     }
     else if (pMtx)
     {
+        // update the c4 position and rotation to follow the target
         DG_SetPos_8001BC44(pMtx);
-        DG_PutVector_8001BE48(work->field_104, &pCtrl->mov, 1);
+        DG_PutVector_8001BE48(work->rotation, &pCtrl->mov, 1);
         DG_MatrixRotYXZ_8001E734(pMtx, &pCtrl->rot);
     }
 }
 
+/**
+ * @brief Cleanup function for the C4 actor. Frees resources and updates the actor list.
+ *
+ * @param work Pointer to the BakudanWork structure.
+ */
 void bakudan_kill_8006A4A4(BakudanWork *work)
 {
     GM_FreeControl_800260CC(&work->control);
     GM_ClearBulName_8004FBE4(work->control.name);
     GM_FreeObject_80034BF8((OBJECT *)&work->field_9C_kmd);
 
-    if (work->field_114 >= 0)
+    if (work->c4_index >= 0)
     {
-        stru_800BDD78[work->field_114].actor = NULL;
+        c4_actors[work->c4_index].actor = NULL;
         bakudan_count_8009F42C--;
     }
 }
 
+/**
+ * @brief Find the next free slot in the c4_actors array.
+ *
+ * @return int Index of the next free slot, or -1 if no free slot is available.
+ */
 int bakudan_next_free_item_8006A510()
 {
     int i;
     for (i = 0; i < 16; i++)
     {
-        if (!stru_800BDD78[i].actor)
+        if (!c4_actors[i].actor)
         {
             return i;
         }
@@ -152,14 +180,26 @@ int bakudan_next_free_item_8006A510()
     return -1;
 }
 
-int bakudan_8006A54C(BakudanWork *work, MATRIX *pMtx, SVECTOR *pVec, int a4, void *data)
+/**
+ * @brief Helper function to initialize a C4 actor.
+ *
+ * @param work Pointer to the BakudanWork structure.
+ * @param pMtx
+ * @param pVec
+ * @param followTarget 1 if the C4 is placed on a moving target, 0 otherwise.
+ * @param data Pointer to the target (wall/floor or moving target). Used to update
+ *            the c4 position and rotation and to delete the c4 when the target is dead)
+* @return int 0 on success, -1 on failure.
+ */
+int bakudan_8006A54C(BakudanWork *work, MATRIX *pMtx, SVECTOR *pVec, int followTarget, void *data)
 {
     CONTROL *pCtrl = &work->control;
     OBJECT_NO_ROTS *pKmd;
     int nextItem;
     HITTABLE *pItem;
 
-    work->field_118 = GM_CurrentMap_800AB9B0 = GM_PlayerMap_800ABA0C;
+
+    work->map_index = GM_CurrentMap_800AB9B0 = GM_PlayerMap_800ABA0C;
 
     if (GM_InitControl_8002599C(pCtrl, GM_Next_BulName_8004FBA0(), 0) < 0)
     {
@@ -169,10 +209,10 @@ int bakudan_8006A54C(BakudanWork *work, MATRIX *pMtx, SVECTOR *pVec, int a4, voi
     GM_ConfigControlHazard_8002622C(pCtrl, 0, 0, 0);
     GM_ConfigControlMatrix_80026154(pCtrl, pMtx);
 
-    if (a4 == 1)
+    if (followTarget == 1)
     {
         work->field_100_pMtx = pMtx;
-        work->field_104 = pVec;
+        work->rotation = pVec;
     }
     else
     {
@@ -191,14 +231,14 @@ int bakudan_8006A54C(BakudanWork *work, MATRIX *pMtx, SVECTOR *pVec, int a4, voi
     GM_ConfigObjectLight_80034C44((OBJECT *)pKmd, work->field_C0_light_mtx);
     pKmd->objs->objs[0].raise = 200;
 
-    work->field_114 = nextItem = bakudan_next_free_item_8006A510();
+    work->c4_index = nextItem = bakudan_next_free_item_8006A510();
 
     if (nextItem < 0)
     {
         return -1;
     }
 
-    pItem = &stru_800BDD78[nextItem];
+    pItem = &c4_actors[nextItem];
     pItem->actor = &work->actor;
     pItem->control = pCtrl;
     pItem->data = data;
@@ -207,10 +247,22 @@ int bakudan_8006A54C(BakudanWork *work, MATRIX *pMtx, SVECTOR *pVec, int a4, voi
     return 0;
 }
 
-GV_ACT *NewBakudan_8006A6CC(MATRIX *pMtx, SVECTOR *pVec, int a3, int not_used, void *data)
+/**
+ * @brief Construct a new c4 actor
+ *
+ * @param pMtx rotation matrix
+ * @param pVec position vector
+ * @param followTarget 1 if the c4 is placed on a moving target, 0 otherwise
+ * @param not_used
+ * @param data Pointer to the target (used to update the c4 position and rotation
+ *            and to delete the c4 when the target is dead)
+ * @return * GV_ACT* pointer to the new c4 actor
+ */
+GV_ACT *NewBakudan_8006A6CC(MATRIX *pMtx, SVECTOR *pVec, int followTarget, int not_used, void *data)
 {
-    BakudanWork *work; // $s0
+    BakudanWork *work;
 
+    // if there are already 16 c4s, don't create a new one
     if (bakudan_count_8009F42C == 16)
     {
         return 0;
@@ -221,18 +273,18 @@ GV_ACT *NewBakudan_8006A6CC(MATRIX *pMtx, SVECTOR *pVec, int a3, int not_used, v
     {
         GV_SetNamedActor_8001514C(&work->actor, (TActorFunction)bakudan_act_8006A218,
                                   (TActorFunction)bakudan_kill_8006A4A4, "bakudan.c");
-        if (bakudan_8006A54C(work, pMtx, pVec, a3, data) < 0)
+        if (bakudan_8006A54C(work, pMtx, pVec, followTarget, data) < 0)
         {
             GV_DestroyActor_800151C8(&work->actor);
             return 0;
         }
-        work->field_10C = 0;
-        work->field_108 = 0;
+        work->detonator_frames_count = 0;
+        work->detonator_btn_pressed = 0;
     }
 #ifdef VR_EXE
-    if (dword_8009F430 > GV_Time_800AB330)
+    if (time_last_press_8009F430 > GV_Time_800AB330)
     {
-        dword_8009F430 = 0;
+        time_last_press_8009F430 = 0;
     }
 #endif
     return &work->actor;

--- a/src/Bullet/bakudan.h
+++ b/src/Bullet/bakudan.h
@@ -17,13 +17,13 @@ typedef struct BakudanWork
     CONTROL        control;
     OBJECT_NO_ROTS field_9C_kmd;
     MATRIX         field_C0_light_mtx[2];
-    MATRIX        *field_100_pMtx;
-    SVECTOR       *field_104;
-    int            field_108;
-    int            field_10C;
-    GV_PAD        *field_110_pPad;
-    int            field_114;
-    int            field_118;
+    MATRIX        *field_100_pMtx;         // (assigned if the c4 is placed on a moving target)
+    SVECTOR       *rotation;               // rotation vector (assigned if the c4 is placed on a moving target)
+    int            detonator_btn_pressed;  // 1 if the detonator button is pressed, 0 otherwise
+    int            detonator_frames_count; // number of actor actions to wait before detonate
+    GV_PAD        *active_pad;             // pointer to the currently active gamepad
+    int            c4_index;               // the index in the c4_actors array
+    int            map_index;              // the current map where the c4 is placed
 } BakudanWork;
 
 GV_ACT *NewBakudan_8006A6CC(MATRIX *pMtx, SVECTOR *pVec, int a3, int not_used, void *data);

--- a/src/Bullet/bakudan.h
+++ b/src/Bullet/bakudan.h
@@ -11,18 +11,20 @@
 
 // c4 (armed)
 
+#define C4_COUNT 16
+
 typedef struct BakudanWork
 {
     GV_ACT         actor;
     CONTROL        control;
-    OBJECT_NO_ROTS field_9C_kmd;
-    MATRIX         field_C0_light_mtx[2];
-    MATRIX        *field_100_pMtx;         // (assigned if the c4 is placed on a moving target)
-    SVECTOR       *rotation;               // rotation vector (assigned if the c4 is placed on a moving target)
+    OBJECT_NO_ROTS kmd;
+    MATRIX         light_mtx[2];
+    MATRIX        *transform;              // transform matrix (assigned if the c4 is placed on a moving target)
+    SVECTOR       *position;               // position (assigned if the c4 is placed on a moving target)
     int            detonator_btn_pressed;  // 1 if the detonator button is pressed, 0 otherwise
     int            detonator_frames_count; // number of actor actions to wait before detonate
     GV_PAD        *active_pad;             // pointer to the currently active gamepad
-    int            c4_index;               // the index in the c4_actors array
+    int            c4_index;               // the index in the c4_actors_800BDD78 array
     int            map_index;              // the current map where the c4 is placed
 } BakudanWork;
 

--- a/src/chara/snake/sna_init.c
+++ b/src/chara/snake/sna_init.c
@@ -115,7 +115,7 @@ extern SVECTOR            GM_PlayerPosition_800ABA10;
 extern UnkCameraStruct    gUnkCameraStruct_800B77B8;
 extern GV_PAD             GV_PadData_800B05C0[4];
 extern CONTROL        *tenage_ctrls_800BDD30[16];
-extern HITTABLE      stru_800BDD78[16];
+extern HITTABLE           c4_actors[16];
 extern HITTABLE      stru_800BDE78[8];
 extern unsigned char      gBulNames_800BDC78[64];
 unsigned char             gBulNames_800BDC78[64];
@@ -3674,10 +3674,12 @@ void sna_bomb_800541A8(SnaInitWork *work, int time)
     work->field_9CC_anim_update_fn_1p = sna_fn_nothing_80053B80;
     if (sna_8004FDE8(work, &stru_8009EFE4[0]))
     {
+        // c4 is attached to a moving target
         pFn = sna_800571B8;
     }
     else
     {
+        // c4 is placed on a static surface
         pFn = sna_80057118;
     }
     sna_start_anim_8004E1F4(work, pFn);
@@ -8572,7 +8574,7 @@ static inline int sna_LoadSnake(SnaInitWork *work, int scriptData, int scriptBin
     dword_800BDD28 = 0;
     tenage_ctrls_count_800BDD70 = 0;
 
-    pJiraiUnk = stru_800BDD78;
+    pJiraiUnk = c4_actors;
     i = 0;
 
     while (i < 16)

--- a/src/chara/snake/sna_init.c
+++ b/src/chara/snake/sna_init.c
@@ -115,7 +115,7 @@ extern SVECTOR            GM_PlayerPosition_800ABA10;
 extern UnkCameraStruct    gUnkCameraStruct_800B77B8;
 extern GV_PAD             GV_PadData_800B05C0[4];
 extern CONTROL        *tenage_ctrls_800BDD30[16];
-extern HITTABLE           c4_actors[16];
+extern HITTABLE           c4_actors_800BDD78[C4_COUNT];
 extern HITTABLE      stru_800BDE78[8];
 extern unsigned char      gBulNames_800BDC78[64];
 unsigned char             gBulNames_800BDC78[64];
@@ -8574,10 +8574,10 @@ static inline int sna_LoadSnake(SnaInitWork *work, int scriptData, int scriptBin
     dword_800BDD28 = 0;
     tenage_ctrls_count_800BDD70 = 0;
 
-    pJiraiUnk = c4_actors;
+    pJiraiUnk = c4_actors_800BDD78;
     i = 0;
 
-    while (i < 16)
+    while (i < C4_COUNT)
     {
         i++;
         pJiraiUnk->type = WEAPON_C4;

--- a/src/chara/snake_vr/sna_init.c
+++ b/src/chara/snake_vr/sna_init.c
@@ -108,7 +108,7 @@ extern SVECTOR            GM_PlayerPosition_800ABA10;
 extern UnkCameraStruct    gUnkCameraStruct_800B77B8;
 extern GV_PAD             GV_PadData_800B05C0[4];
 extern CONTROL        *tenage_ctrls_800BDD30[16];
-extern HITTABLE      stru_800BDD78[16];
+extern HITTABLE      c4_actors[16];
 extern HITTABLE      stru_800BDE78[8];
 extern unsigned char      gBulNames_800BDC78[64];
 unsigned char             gBulNames_800BDC78[64];
@@ -8175,7 +8175,7 @@ static inline int sna_LoadSnake(SnaInitWork *work, int scriptData, int scriptBin
     dword_800BDD28 = 0;
     tenage_ctrls_count_800BDD70 = 0;
 
-    pJiraiUnk = stru_800BDD78;
+    pJiraiUnk = c4_actors;
     i = 0;
 
     while (i < 16)

--- a/src/chara/snake_vr/sna_init.c
+++ b/src/chara/snake_vr/sna_init.c
@@ -108,7 +108,7 @@ extern SVECTOR            GM_PlayerPosition_800ABA10;
 extern UnkCameraStruct    gUnkCameraStruct_800B77B8;
 extern GV_PAD             GV_PadData_800B05C0[4];
 extern CONTROL        *tenage_ctrls_800BDD30[16];
-extern HITTABLE      c4_actors[16];
+extern HITTABLE           c4_actors_800BDD78[C4_COUNT];
 extern HITTABLE      stru_800BDE78[8];
 extern unsigned char      gBulNames_800BDC78[64];
 unsigned char             gBulNames_800BDC78[64];
@@ -8175,10 +8175,10 @@ static inline int sna_LoadSnake(SnaInitWork *work, int scriptData, int scriptBin
     dword_800BDD28 = 0;
     tenage_ctrls_count_800BDD70 = 0;
 
-    pJiraiUnk = c4_actors;
+    pJiraiUnk = c4_actors_800BDD78;
     i = 0;
 
-    while (i < 16)
+    while (i < C4_COUNT)
     {
         i++;
         pJiraiUnk->type = WEAPON_C4;

--- a/src/data/bss.c
+++ b/src/data/bss.c
@@ -261,7 +261,7 @@ int BSS             tenage_ctrls_count_800BDD70; // 0x4 (4) bytes
 
 gap                                     gap_800BDD74[0x4]; // 4 bytes
 
-HITTABLE BSS   stru_800BDD78[16]; // 0x100 (256) bytes
+HITTABLE BSS        c4_actors[16]; // 0x100 (256) bytes
 HITTABLE BSS   stru_800BDE78[8]; // 0x80 (128) bytes
 int BSS             dword_800BDEF8[2]; // 0x8 (8) bytes
 TARGET *BSS         target_800BDF00; // 0x4 (4) bytes

--- a/src/data/bss.c
+++ b/src/data/bss.c
@@ -18,6 +18,7 @@
 #include "SD/sd_incl.h"
 #include "Game/camera.h"
 #include "Equip/jpegcam.h"
+#include "Bullet/bakudan.h"
 
 #define BSS SECTION(".bss")
 #define gap char BSS
@@ -261,7 +262,7 @@ int BSS             tenage_ctrls_count_800BDD70; // 0x4 (4) bytes
 
 gap                                     gap_800BDD74[0x4]; // 4 bytes
 
-HITTABLE BSS        c4_actors[16]; // 0x100 (256) bytes
+HITTABLE BSS        c4_actors_800BDD78[C4_COUNT]; // 0x100 (256) bytes
 HITTABLE BSS   stru_800BDE78[8]; // 0x80 (128) bytes
 int BSS             dword_800BDEF8[2]; // 0x8 (8) bytes
 TARGET *BSS         target_800BDF00; // 0x4 (4) bytes

--- a/src/overlays/s00a/Takabe/elevator.c
+++ b/src/overlays/s00a/Takabe/elevator.c
@@ -6,6 +6,7 @@
 #include "Game/object.h"
 #include "Game/vibrate.h"
 #include "Takabe/thing.h"
+#include "Bullet/bakudan.h"
 
 typedef struct _ElevatorWork
 {
@@ -69,7 +70,7 @@ extern int           GM_AlertMode_800ABA00;
 extern CONTROL      *GM_WhereList_800B56D0[96];
 extern CONTROL      *tenage_ctrls_800BDD30[16];
 extern int           tenage_ctrls_count_800BDD70;
-extern HITTABLE      c4_actors[16];
+extern HITTABLE      c4_actors_800BDD78[C4_COUNT];
 extern HITTABLE stru_800BDE78[8];
 
 unsigned short elevator_hash_800C3634[4] = {0xACDC, 0x085B, 0x804B, 0xDBC9};
@@ -303,8 +304,8 @@ void ElevatorAct_800D8EA8(ElevatorWork *work)
         // translate the position of the c4 actors if they are on the elevator
         if (bakudan_count_8009F42C != 0)
         {
-            bomb = c4_actors;
-            for (j = 16; j > 0; j--)
+            bomb = c4_actors_800BDD78;
+            for (j = C4_COUNT; j > 0; j--)
             {
                 // check if the c4 is on the walls or floors of the elevator
                 if (bomb->actor && Elevator_800DA464(work, bomb->data))

--- a/src/overlays/s00a/Takabe/elevator.c
+++ b/src/overlays/s00a/Takabe/elevator.c
@@ -69,7 +69,7 @@ extern int           GM_AlertMode_800ABA00;
 extern CONTROL      *GM_WhereList_800B56D0[96];
 extern CONTROL      *tenage_ctrls_800BDD30[16];
 extern int           tenage_ctrls_count_800BDD70;
-extern HITTABLE stru_800BDD78[16];
+extern HITTABLE      c4_actors[16];
 extern HITTABLE stru_800BDE78[8];
 
 unsigned short elevator_hash_800C3634[4] = {0xACDC, 0x085B, 0x804B, 0xDBC9};
@@ -300,12 +300,13 @@ void ElevatorAct_800D8EA8(ElevatorWork *work)
                 where++;
             }
         }
-
+        // translate the position of the c4 actors if they are on the elevator
         if (bakudan_count_8009F42C != 0)
         {
-            bomb = stru_800BDD78;
+            bomb = c4_actors;
             for (j = 16; j > 0; j--)
             {
+                // check if the c4 is on the walls or floors of the elevator
                 if (bomb->actor && Elevator_800DA464(work, bomb->data))
                 {
                     GV_AddVec3_80016D00(&bomb->control->mov, &sp10, &bomb->control->mov);
@@ -915,6 +916,14 @@ void Elevator_800DA3F8(ElevatorWork *work, HZD_AREA *area)
     }
 }
 
+/**
+ * @brief Check if the given pointer is in the list of walls or floors.
+ *  Used to check if c4 or claymores are on the elevator.
+ *
+ * @param work ElevatorWork actor
+ * @param ptr Pointer to check
+ * @return int 1 if the target is a wall or floor, 0 otherwise
+ */
 int Elevator_800DA464(ElevatorWork *work, void *ptr)
 {
     HZD_SEG *wall;

--- a/src/overlays/s04a/Takabe/dummy_wl.c
+++ b/src/overlays/s04a/Takabe/dummy_wl.c
@@ -53,7 +53,7 @@ void     Takabe_FreeObjs_800DC820(DG_OBJS *objs);
 void     s16b_800C49AC(HZD_SEG *seg);
 DG_OBJS *s00a_unknown3_800DC7BC(int model, LitHeader *lit);
 
-extern HITTABLE stru_800BDD78[16];
+extern HITTABLE c4_actors[16];
 extern SVECTOR       DG_ZeroVector_800AB39C;
 
 void DummyWall_800D7418(OBJECT *obj, int model, int where, int flag);
@@ -88,7 +88,7 @@ void DummyWallAct_800D6E64(DummyWallWork *work)
             HZD_DequeueDynamicSegment_8006FE44(work->field_198, &work->field_19C);
             work->field_194 = 0;
 
-            jirai = stru_800BDD78;
+            jirai = c4_actors;
             for (i = 16; i > 0; i--, jirai++)
             {
                 if (jirai->actor && jirai->data == &work->field_19C)

--- a/src/overlays/s04a/Takabe/dummy_wl.c
+++ b/src/overlays/s04a/Takabe/dummy_wl.c
@@ -5,6 +5,7 @@
 #include "Game/hittable.h"
 #include "Game/object.h"
 #include "Takabe/thing.h"
+#include "Bullet/bakudan.h"
 
 typedef struct DummyWallWork
 {
@@ -53,7 +54,7 @@ void     Takabe_FreeObjs_800DC820(DG_OBJS *objs);
 void     s16b_800C49AC(HZD_SEG *seg);
 DG_OBJS *s00a_unknown3_800DC7BC(int model, LitHeader *lit);
 
-extern HITTABLE c4_actors[16];
+extern HITTABLE      c4_actors_800BDD78[C4_COUNT];
 extern SVECTOR       DG_ZeroVector_800AB39C;
 
 void DummyWall_800D7418(OBJECT *obj, int model, int where, int flag);
@@ -88,8 +89,8 @@ void DummyWallAct_800D6E64(DummyWallWork *work)
             HZD_DequeueDynamicSegment_8006FE44(work->field_198, &work->field_19C);
             work->field_194 = 0;
 
-            jirai = c4_actors;
-            for (i = 16; i > 0; i--, jirai++)
+            jirai = c4_actors_800BDD78;
+            for (i = C4_COUNT; i > 0; i--, jirai++)
             {
                 if (jirai->actor && jirai->data == &work->field_19C)
                 {

--- a/src/overlays/s11c/Takabe/rasen.c
+++ b/src/overlays/s11c/Takabe/rasen.c
@@ -80,7 +80,7 @@ extern MATRIX          DG_ZeroMatrix_8009D430;
 extern CONTROL        *GM_WhereList_800B56D0[96];
 extern int             gControlCount_800AB9B4;
 extern int             bakudan_count_8009F42C;
-extern HITTABLE   stru_800BDD78[16];
+extern HITTABLE        c4_actors[16];
 extern HITTABLE   stru_800BDE78[8];
 extern int             counter_8009F448;
 extern CONTROL        *GM_PlayerControl_800AB9F4;
@@ -115,7 +115,7 @@ void Rasen2IterBakudanJirai_800CA3A4(Rasen2Work *work, MAP *oldMap, MAP *newMap)
 
     if (bakudan_count_8009F42C != 0)
     {
-        for (pItem = stru_800BDD78, i = 16; i > 0; pItem++, i--)
+        for (pItem = c4_actors, i = 16; i > 0; pItem++, i--)
         {
             bakudan = (BakudanWork *)pItem->actor;
             if (bakudan != NULL && bakudan->control.map == oldMap && bakudan->field_100_pMtx == NULL)
@@ -128,7 +128,7 @@ void Rasen2IterBakudanJirai_800CA3A4(Rasen2Work *work, MAP *oldMap, MAP *newMap)
                 {
                     bakudan->control.map = newMap;
                     bakudan->control.mov.vy += yoff;
-                    bakudan->field_118 = newMap->index;
+                    bakudan->map_index = newMap->index;
                 }
             }
         }

--- a/src/overlays/s11c/Takabe/rasen.c
+++ b/src/overlays/s11c/Takabe/rasen.c
@@ -80,7 +80,7 @@ extern MATRIX          DG_ZeroMatrix_8009D430;
 extern CONTROL        *GM_WhereList_800B56D0[96];
 extern int             gControlCount_800AB9B4;
 extern int             bakudan_count_8009F42C;
-extern HITTABLE        c4_actors[16];
+extern HITTABLE        c4_actors_800BDD78[C4_COUNT];
 extern HITTABLE   stru_800BDE78[8];
 extern int             counter_8009F448;
 extern CONTROL        *GM_PlayerControl_800AB9F4;
@@ -115,10 +115,10 @@ void Rasen2IterBakudanJirai_800CA3A4(Rasen2Work *work, MAP *oldMap, MAP *newMap)
 
     if (bakudan_count_8009F42C != 0)
     {
-        for (pItem = c4_actors, i = 16; i > 0; pItem++, i--)
+        for (pItem = c4_actors_800BDD78, i = C4_COUNT; i > 0; pItem++, i--)
         {
             bakudan = (BakudanWork *)pItem->actor;
-            if (bakudan != NULL && bakudan->control.map == oldMap && bakudan->field_100_pMtx == NULL)
+            if (bakudan != NULL && bakudan->control.map == oldMap && bakudan->transform == NULL)
             {
                 if ((bakudan->control.mov.vy ^ bitmask) & 0x8000)
                 {

--- a/src/overlays/s13a/Takabe/lift.c
+++ b/src/overlays/s13a/Takabe/lift.c
@@ -2,6 +2,7 @@
 #include "Game/hittable.h"
 #include "Game/object.h"
 #include "Takabe/thing.h"
+#include "Bullet/bakudan.h"
 
 typedef struct _LiftWork
 {
@@ -26,7 +27,7 @@ typedef struct _LiftWork
 extern int      bakudan_count_8009F42C;
 extern int      counter_8009F448;
 extern SVECTOR  DG_ZeroVector_800AB39C;
-extern HITTABLE c4_actors[16];
+extern HITTABLE c4_actors_800BDD78[C4_COUNT];
 extern HITTABLE stru_800BDE78[8];
 
 #define TAG(ptr, tag) ((void *)((unsigned int)ptr | tag))
@@ -182,10 +183,10 @@ void LiftAct_800DDBFC(LiftWork *work)
 
     if (bakudan_count_8009F42C != 0)
     {
-        i = 16;
+        i = C4_COUNT;
         floor = &work->floor;
         tag = 0x80000000;
-        iter = c4_actors;
+        iter = c4_actors_800BDD78;
         for (; i > 0; iter++, i--)
         {
             if (iter->actor && floor == TAG(iter->data, tag))

--- a/src/overlays/s13a/Takabe/lift.c
+++ b/src/overlays/s13a/Takabe/lift.c
@@ -26,7 +26,7 @@ typedef struct _LiftWork
 extern int      bakudan_count_8009F42C;
 extern int      counter_8009F448;
 extern SVECTOR  DG_ZeroVector_800AB39C;
-extern HITTABLE stru_800BDD78[16];
+extern HITTABLE c4_actors[16];
 extern HITTABLE stru_800BDE78[8];
 
 #define TAG(ptr, tag) ((void *)((unsigned int)ptr | tag))
@@ -185,7 +185,7 @@ void LiftAct_800DDBFC(LiftWork *work)
         i = 16;
         floor = &work->floor;
         tag = 0x80000000;
-        iter = stru_800BDD78;
+        iter = c4_actors;
         for (; i > 0; iter++, i--)
         {
             if (iter->actor && floor == TAG(iter->data, tag))

--- a/src/overlays/s16b/unknown2.c
+++ b/src/overlays/s16b/unknown2.c
@@ -1,8 +1,9 @@
 #include "Game/hittable.h"
+#include "Bullet/bakudan.h"
 
 extern int      bakudan_count_8009F42C;
 extern int      counter_8009F448;
-extern HITTABLE c4_actors[16];
+extern HITTABLE c4_actors_800BDD78[C4_COUNT];
 extern HITTABLE stru_800BDE78[8];
 
 int s16b_800C4820(HZD_SEG *find, int count, HZD_SEG *segs)
@@ -42,7 +43,7 @@ void s16b_800C4874(int n_segs, HZD_SEG *segs, int n_flrs, HZD_FLR *flrs)
 
     if (bakudan_count_8009F42C != 0)
     {
-        for (i = 16, tag = 0x80000000, iter = c4_actors; i > 0; i--, iter++)
+        for (i = C4_COUNT, tag = 0x80000000, iter = c4_actors_800BDD78; i > 0; i--, iter++)
         {
             if (iter->actor)
             {

--- a/src/overlays/s16b/unknown2.c
+++ b/src/overlays/s16b/unknown2.c
@@ -2,7 +2,7 @@
 
 extern int      bakudan_count_8009F42C;
 extern int      counter_8009F448;
-extern HITTABLE stru_800BDD78[16];
+extern HITTABLE c4_actors[16];
 extern HITTABLE stru_800BDE78[8];
 
 int s16b_800C4820(HZD_SEG *find, int count, HZD_SEG *segs)
@@ -42,7 +42,7 @@ void s16b_800C4874(int n_segs, HZD_SEG *segs, int n_flrs, HZD_FLR *flrs)
 
     if (bakudan_count_8009F42C != 0)
     {
-        for (i = 16, tag = 0x80000000, iter = stru_800BDD78; i > 0; i--, iter++)
+        for (i = 16, tag = 0x80000000, iter = c4_actors; i > 0; i--, iter++)
         {
             if (iter->actor)
             {


### PR DESCRIPTION
I did some renaming for the C4 actor and added some documentation the best I could.


Not 100% about how pMtx is used. But for sure is used for when the player attach the c4 to something that is moving like an enemy.

Can I safely remove the address of some variables? for example
```
int bakudan_count_8009F42C = 0;
int time_last_press_8009F430 = 0;
```

I guess that now is ok for the main exe but not yet ok for the overlays