### PR TITLE
Rename Work structs, cleanup SD, start on extern deduplication

### DIFF
--- a/src/Equip/jpegcam.h
+++ b/src/Equip/jpegcam.h
@@ -33,7 +33,7 @@ typedef struct JpegCamWork
     char          *field_84;
     char          *field_88;
     int            field_8C_size;
-    Actor_Sight   *field_90_pSight;
+    SightWork     *field_90_pSight;
     int            field_94_bMakeVisible;
     int            field_98;
 } JpegCamWork;

--- a/src/Game/game.h
+++ b/src/Game/game.h
@@ -15,11 +15,6 @@
 #include "SD/sound.h"
 #include "SD/g_sound.h"
 
-extern int     GM_CurrentMap_800AB9B0;
-extern int     GM_NoisePower_800ABA24;
-extern int     GM_NoiseLength_800ABA30;
-extern SVECTOR GM_NoisePosition_800AB9F8;
-
 #define ACTOR_LIST_COUNT 9
 
 enum GAMED_STATE {
@@ -137,6 +132,13 @@ enum // GM_GameStatus_800AB3CC
     STATE_PADRELEASE = 0x10000000,
 };
 
+/*---------------------------------------------------------------------------*/
+#ifndef __BSSDEFINE__
+extern int     GM_CurrentMap_800AB9B0;
+extern int     GM_NoisePower_800ABA24;
+extern int     GM_NoiseLength_800ABA30;
+extern SVECTOR GM_NoisePosition_800AB9F8;
+
 static inline void GM_SetNoise( int power, int length, SVECTOR *pos )
 {
     int old = GM_NoisePower_800ABA24;
@@ -208,6 +210,9 @@ int                     alert ;
         if ( alert > GM_AlertMax ) GM_AlertMax = alert ;
 }
 */
+
+#endif // __BSSDEFINE__
+/*---------------------------------------------------------------------------*/
 
 void               GM_Act_8002ADBC(GameWork *work);
 void               GM_InitArea_8002A704(void);

--- a/src/Game/vibrate.c
+++ b/src/Game/vibrate.c
@@ -11,7 +11,7 @@ extern unsigned char *GCL_NextStrPtr_800AB9A0;
 extern int            GM_PadVibration_800ABA3C;
 extern int            GM_PadVibration2_800ABA54;
 
-int vibrate_act_helper_8005D358(Actor_Vibrate *work)
+int vibrate_act_helper_8005D358(VibrateWork *work)
 {
     unsigned char *pData;
 
@@ -27,7 +27,7 @@ int vibrate_act_helper_8005D358(Actor_Vibrate *work)
     return 1;
 }
 
-int vibrate_act_helper_8005D3A4(Actor_Vibrate *work)
+int vibrate_act_helper_8005D3A4(VibrateWork *work)
 {
     GCL_SetArgTop_80020690(work->field_24_pData);
 
@@ -46,7 +46,7 @@ int vibrate_act_helper_8005D3A4(Actor_Vibrate *work)
     return 1;
 }
 
-void vibrate_act_8005D424(Actor_Vibrate *work)
+void vibrate_act_8005D424(VibrateWork *work)
 {
     int amount;
     int bAlive;
@@ -83,13 +83,13 @@ void vibrate_act_8005D424(Actor_Vibrate *work)
     }
 }
 
-Actor_Vibrate *vibrate_init_8005D508(int pan)
+VibrateWork *vibrate_init_8005D508(int pan)
 {
-    Actor_Vibrate   *work;
+    VibrateWork     *work;
     char            flags;
     unsigned char   *pData;
 
-    work = (Actor_Vibrate *)GV_NewActor_800150E4(5, sizeof(Actor_Vibrate));
+    work = (VibrateWork *)GV_NewActor_800150E4(5, sizeof(VibrateWork));
     if (work)
     {
         GV_SetNamedActor_8001514C(&work->actor,
@@ -108,11 +108,11 @@ Actor_Vibrate *vibrate_init_8005D508(int pan)
     return work;
 }
 
-Actor_Vibrate *NewPadVibration_8005D58C(unsigned char *pData, int flags)
+VibrateWork *NewPadVibration_8005D58C(unsigned char *pData, int flags)
 {
-    Actor_Vibrate *work;
+    VibrateWork *work;
 
-    work = (Actor_Vibrate *)GV_NewActor_800150E4(5, sizeof(Actor_Vibrate));
+    work = (VibrateWork *)GV_NewActor_800150E4(5, sizeof(VibrateWork));
     if (work)
     {
         GV_SetNamedActor_8001514C(&work->actor,

--- a/src/Game/vibrate.h
+++ b/src/Game/vibrate.h
@@ -3,20 +3,20 @@
 
 #include "libgv/libgv.h"
 
-typedef struct      Actor_Vibrate
+typedef struct      VibrateWork
 {
     GV_ACT          actor;
     char            field_20_flags;
     char            field_21_increment;
     short           field_22_timer;
     unsigned char   *field_24_pData;
-} Actor_Vibrate;
+} VibrateWork;
 
-int                 vibrate_act_helper_8005D358(Actor_Vibrate *);
-int                 vibrate_act_helper_8005D3A4(Actor_Vibrate *);
-void                vibrate_act_8005D424(Actor_Vibrate *);
+int                 vibrate_act_helper_8005D358(VibrateWork *);
+int                 vibrate_act_helper_8005D3A4(VibrateWork *);
+void                vibrate_act_8005D424(VibrateWork *);
 
-Actor_Vibrate       *vibrate_init_8005D508(int);
-Actor_Vibrate       *NewPadVibration_8005D58C(unsigned char *, int);
+VibrateWork         *vibrate_init_8005D508(int);
+VibrateWork         *NewPadVibration_8005D58C(unsigned char *, int);
 
 #endif // _VIBRATE_H_

--- a/src/Kojo/demo.c
+++ b/src/Kojo/demo.c
@@ -3599,7 +3599,7 @@ void demothrd_Screen_Chanl_80080D48(DG_CHNL *pChnl, int idx)
     }
 }
 
-void M1E1Caterpiller(Actor_m1e1 *work)
+void M1E1Caterpiller(M1E1Work *work)
 {
     SVECTOR sp10;
     SVECTOR sp18;

--- a/src/Kojo/demothrd.h
+++ b/src/Kojo/demothrd.h
@@ -678,7 +678,7 @@ typedef struct dmo_data_0x36
     } data;
 } dmo_data_0x36;
 
-typedef struct Actor_m1e1
+typedef struct M1E1Work
 {
     GV_ACT  actor;
     CONTROL control;
@@ -716,7 +716,7 @@ typedef struct Actor_m1e1
     int     field_F6C;
     int     field_F70;
     int     field_F74;
-} Actor_m1e1;
+} M1E1Work;
 
 int  DM_ThreadStream_80079460(int flag, int unused);
 int  DM_ThreadFile_800794E4(int param_1, int param_2);

--- a/src/Menu/datasave.c
+++ b/src/Menu/datasave.c
@@ -118,7 +118,7 @@ int dword_8009E774[] = {
     0x1221111,  0xEA00102,  0x22222333, 0xB000301,  0,          0
 };
 
-extern Actor_MenuMan gMenuMan_800BD360;
+extern MenuWork gMenuWork_800BD360;
 
 extern mem_card  *mcd_last_file_800ABB68[];
 extern const int  dword_800120B4[];
@@ -1020,7 +1020,7 @@ void set_sprt_default_8004AE14(SPRT *pSprt)
     pSprt->clut = 32700;
 }
 
-void menu_radio_do_file_mode_helper7_8004AE3C(Actor_MenuMan *param_1, const char *str)
+void menu_radio_do_file_mode_helper7_8004AE3C(MenuWork *param_1, const char *str)
 {
     int height;
     KCB  *kcb;
@@ -1080,7 +1080,7 @@ void sub_8004AEA8(SELECT_INFO *info)
     font_update_8004695C(kcb);
 }
 
-void menu_radio_do_file_mode_helper8_8004AFE4(Actor_MenuMan *work, char *pOt, SELECT_INFO *info)
+void menu_radio_do_file_mode_helper8_8004AFE4(MenuWork *work, char *pOt, SELECT_INFO *info)
 {
     KCB  *kcb;
     SPRT *sprt;
@@ -1096,7 +1096,7 @@ void menu_radio_do_file_mode_helper8_8004AFE4(Actor_MenuMan *work, char *pOt, SE
     addPrim(pOt, sprt);
 }
 
-void menu_radio_do_file_mode_save_memcard_8004B0A0(Actor_MenuMan *work, char *pOt, SELECT_INFO *info)
+void menu_radio_do_file_mode_save_memcard_8004B0A0(MenuWork *work, char *pOt, SELECT_INFO *info)
 {
     TextConfig config;
 
@@ -1490,7 +1490,7 @@ void sub_8004B9C4(SELECT_INFO *info, int param_2)
 }
 
 
-int menu_radio_do_file_mode_helper12_8004BA80(Actor_MenuMan *work, mem_card *pMemcard, const char *param_3,
+int menu_radio_do_file_mode_helper12_8004BA80(MenuWork *work, mem_card *pMemcard, const char *param_3,
                                               SELECT_INFO *info)
 {
     MENU_CURPOS *pIter;
@@ -1646,7 +1646,7 @@ int menu_radio_do_file_mode_helper13_8004BCF8(GV_PAD *pPad, int *pOut, SELECT_IN
 
 const char *gMemoryCardNames_8009EC00[] = {"MEMORY CARD 1", "MEMORY CARD 2"};
 
-void menu_radio_do_file_mode_helper14_8004BE98(Actor_MenuMan *work, char *param_2, SELECT_INFO *info)
+void menu_radio_do_file_mode_helper14_8004BE98(MenuWork *work, char *param_2, SELECT_INFO *info)
 {
     MENU_CURPOS *infoChild;
     int                  idx, idx_copy;
@@ -1706,7 +1706,7 @@ void menu_radio_do_file_mode_helper14_8004BE98(Actor_MenuMan *work, char *param_
     info->field_A = 0;
 }
 
-void menu_radio_do_file_mode_helper15_8004C04C(Actor_MenuMan *work, const char **srcs, int cnt, int field_4, const char *field_20,
+void menu_radio_do_file_mode_helper15_8004C04C(MenuWork *work, const char **srcs, int cnt, int field_4, const char *field_20,
                                                SELECT_INFO *info)
 {
     KCB                 *kcb;
@@ -1830,7 +1830,7 @@ int menu_radio_do_file_mode_helper17_8004C2E4(GV_PAD *pPad, int *outParam, SELEC
     return 0;
 }
 
-int menu_radio_do_file_mode_8004C418(Actor_MenuMan *work, GV_PAD *pPad)
+int menu_radio_do_file_mode_8004C418(MenuWork *work, GV_PAD *pPad)
 {
     TextConfig     textConfig1, textConfig2;
     int            res1, res2, res3;
@@ -2316,16 +2316,16 @@ void menu_radio_update_helper4_8004D2D0(int param_1)
 
 void menu_radio_8004D2FC(DATA_INFO *pSaveMode)
 {
-    init_radio_message_board_80040F74(&gMenuMan_800BD360);
+    init_radio_message_board_80040F74(&gMenuWork_800BD360);
     init_file_mode_8004D24C(pSaveMode, 0);
 }
 
 int menu_radio_8004D334(GV_PAD *pPad)
 {
-    return menu_radio_do_file_mode_8004C418(&gMenuMan_800BD360, pPad);
+    return menu_radio_do_file_mode_8004C418(&gMenuWork_800BD360, pPad);
 }
 
 void menu_radio_8004D35C(void)
 {
-    sub_8004124C(&gMenuMan_800BD360);
+    sub_8004124C(&gMenuWork_800BD360);
 }

--- a/src/Menu/debug.c
+++ b/src/Menu/debug.c
@@ -17,7 +17,7 @@ short        SECTION(".sbss") word_800ABB22;
 extern DG_TEX *dword_800ABB24;
 DG_TEX        *SECTION(".sbss") dword_800ABB24;
 
-int menu_draw_mem_debug_80043678(Actor_MenuMan *work, unsigned int *pOt)
+int menu_draw_mem_debug_80043678(MenuWork *work, unsigned int *pOt)
 {
     GV_Heap             *pHeap;
     LINE_F2             *pLine;
@@ -137,7 +137,7 @@ extern GV_PAD GV_PadData_800B05C0[4];
 
 extern unsigned short gOldRootCnt_800B1DC8[32];
 
-int menu_draw_pow_debug_80043A24(Actor_MenuMan *work, unsigned int *pOt)
+int menu_draw_pow_debug_80043A24(MenuWork *work, unsigned int *pOt)
 {
     int             prims_used, left, right, bottom, idx, i;
     unsigned short *pCount;
@@ -275,7 +275,7 @@ int menu_draw_pow_debug_80043A24(Actor_MenuMan *work, unsigned int *pOt)
     return prims_used;
 }
 
-int menu_draw_ply_debug_80043FD0(Actor_MenuMan *pMenuMan, unsigned int *pOt)
+int menu_draw_ply_debug_80043FD0(MenuWork *work, unsigned int *pOt)
 {
     u_char       *chnlOt;
     int           numOTEntries;
@@ -303,7 +303,7 @@ int menu_draw_ply_debug_80043FD0(Actor_MenuMan *pMenuMan, unsigned int *pOt)
     chnlOt = DG_Chanl(0)->mOrderingTables[1 - GV_Clock_800AB920];
     numOTEntries = DG_Chanl(0)->word_6BC374_8 - 4;
 
-    NEW_PRIM(lineF2, pMenuMan);
+    NEW_PRIM(lineF2, work);
 
     setXY2(lineF2, 0x20, 0x76, 0x110, 0x76);
     LSTORE(0x800000, &lineF2->r0);
@@ -337,7 +337,7 @@ int menu_draw_ply_debug_80043FD0(Actor_MenuMan *pMenuMan, unsigned int *pOt)
                 primCount = 176;
             }
 
-            NEW_PRIM(lineG4, pMenuMan);
+            NEW_PRIM(lineG4, work);
             setXY4(lineG4, x_0_1, y_0_1, x_0_1, y_0_1 - primCount, x_2_3, y_2_3 - primCount, x_2_3, y_2_3);
             LSTORE(0, &lineG4->r0);
             LSTORE(0xff00, &lineG4->r1);
@@ -349,7 +349,7 @@ int menu_draw_ply_debug_80043FD0(Actor_MenuMan *pMenuMan, unsigned int *pOt)
         }
         else
         {
-            NEW_PRIM(lineG4, pMenuMan);
+            NEW_PRIM(lineG4, work);
             setXY4(lineG4, x_0_1, y_0_1, x_0_1, y_0_1, x_2_3, y_2_3, x_2_3, y_2_3);
             LSTORE(0, &lineG4->r0);
             LSTORE(0xff0000, &lineG4->r1);
@@ -360,12 +360,12 @@ int menu_draw_ply_debug_80043FD0(Actor_MenuMan *pMenuMan, unsigned int *pOt)
         }
     }
 
-    menu_number_draw_80042F78(pMenuMan, pOt, 0x110, 0x9c, totalprimCount, 1);
+    menu_number_draw_80042F78(work, pOt, 0x110, 0x9c, totalprimCount, 1);
 
     return returnVal;
 }
 
-int menu_draw_obj_debug_800442E4(Actor_MenuMan *work, unsigned int *pOt)
+int menu_draw_obj_debug_800442E4(MenuWork *work, unsigned int *pOt)
 {
     DG_OBJS **ppQueue;
     DG_OBJS  *pObjs;
@@ -484,7 +484,7 @@ int menu_draw_obj_debug_800442E4(Actor_MenuMan *work, unsigned int *pOt)
 
 extern GV_PAD GV_PadData_800B05C0[4];
 
-int menu_draw_tex_debug_800445F8(Actor_MenuMan *work, unsigned int *pOt)
+int menu_draw_tex_debug_800445F8(MenuWork *work, unsigned int *pOt)
 {
     const int textureRecsCount = sizeof(TexSets_800B1F50) / sizeof(TexSets_800B1F50[0]);
     short     x0, y0;
@@ -615,7 +615,7 @@ char *menu_debug_screen_labels_8009E744[] = {
     "tex",
 };
 
-void menu_viewer_act_800448C0(Actor_MenuMan *work, unsigned int *pOt)
+void menu_viewer_act_800448C0(MenuWork *work, unsigned int *pOt)
 {
     mts_read_pad_8008C25C(2);
     if (GM_GameStatus_800AB3CC & GAME_FLAG_BIT_25)
@@ -650,14 +650,14 @@ void menu_viewer_act_800448C0(Actor_MenuMan *work, unsigned int *pOt)
     }
 }
 
-void menu_viewer_init_80044A70(Actor_MenuMan *param_1)
+void menu_viewer_init_80044A70(MenuWork *work)
 {
     menu_current_debug_screen_800ABB20 = 0;
     dword_800ABB24 = TexSets_800B1F50;
     word_800ABB22 = -1;
 }
 
-void menu_viewer_kill_80044A90(Actor_MenuMan *work)
+void menu_viewer_kill_80044A90(MenuWork *work)
 {
     menu_current_debug_screen_800ABB20 = 0;
     return;

--- a/src/Menu/item.c
+++ b/src/Menu/item.c
@@ -181,8 +181,6 @@ char *SECTION(".data") dword_8009E444[] = {
              0x90, 0x48, 0x90, 0x49, 0x81, 0x27, 0x81, 0x0D, 0x81, 0x2A, 0x81, 0x04, 0xD0, 0x03, 0x00, 0x00},
 };
 
-// TODO: This (whole?) buffer is very likely a EUC-JP/SHIFT-JIS string.
-// It starts with SHIFT-JIS: "ｰ針震人仁刃ﾐ" and then EUC-JP: "|HARD, EXTREM B"
 char SECTION(".data") dword_8009E44C[] = {
     0xB0, 0x14, 0x90, 0x6A, 0x90, 0x6B, 0x90, 0x6C, 0x90, 0x6D, 0x90, 0x6E, 0xD0, 0x15, 0x80, 0x7C, 0x48, 0x41, 0x52,
     0x44, 0x2C, 0x20, 0x45, 0x58, 0x54, 0x52, 0x45, 0x4D, 0x20, 0x82, 0x42, 0xD0, 0x06, 0x82, 0x29, 0x81, 0x27, 0x81,
@@ -195,14 +193,14 @@ menu_weapon_rpk_info SECTION(".data") gMenuItemRpkInfo_8009E484[] = {
     {"TIMER.B", 26}, {"MINE.D", 20},  {"DISC", 28},     {"ROPE", 24},     {"SCARF", 29},   {"SUPPR.", 13}};
 
 void sub_8003CEF8(PANEL_TEXTURE *a1);
-int  menu_number_draw_number2_80042FC0(Actor_MenuMan *work, int xpos, int ypos, int current, int total);
+int  menu_number_draw_number2_80042FC0(MenuWork *work, int xpos, int ypos, int current, int total);
 void menu_init_sprt_8003D0D0(SPRT *pPrim, PANEL_TEXTURE *pUnk, int offset_x, int offset_y);
-int  menu_number_draw_string_800430F0(Actor_MenuMan *work, unsigned int *pOt, int xpos, int ypos, const char *str,
+int  menu_number_draw_string_800430F0(MenuWork *work, unsigned int *pOt, int xpos, int ypos, const char *str,
                                       int flags);
-void menu_sub_menu_update_8003DA0C(Actor_MenuMan *work, unsigned int *pOt, Menu_Inventory *pSubMenu);
+void menu_sub_menu_update_8003DA0C(MenuWork *work, unsigned int *pOt, Menu_Inventory *pSubMenu);
 void Menu_item_render_frame_rects_8003DBAC(MenuPrim *pGlue, int x, int y, int param_4);
 int  menu_8003D538(void);
-void menu_8003D7DC(Actor_MenuMan *work, unsigned int *pOt, Menu_Inventory *pSubMenu);
+void menu_8003D7DC(MenuWork *work, unsigned int *pOt, Menu_Inventory *pSubMenu);
 int  sub_8003D568(void);
 
 void menu_sub_8003B568(void)
@@ -294,7 +292,7 @@ int menu_item_IsItemDisabled_8003B6D0(int item)
     return (GM_DisableItem_800ABA28 & bit) != 0;
 }
 
-void menu_8003B794(Actor_MenuMan *work, unsigned int *pOt, int id)
+void menu_8003B794(MenuWork *work, unsigned int *pOt, int id)
 {
     RECT           pal_rect;
     RECT           img_rect;
@@ -331,7 +329,7 @@ void menu_8003B794(Actor_MenuMan *work, unsigned int *pOt, int id)
     addPrim(pOt, pSprt);
 }
 
-void menu_item_helper_8003B8F0(Actor_MenuMan *work, unsigned int *pOt, int xpos, int ypos, Menu_Inventory *pMenuSub)
+void menu_item_helper_8003B8F0(MenuWork *work, unsigned int *pOt, int xpos, int ypos, Menu_Inventory *pMenuSub)
 {
     PANEL_TEXTURE *pMenuSprt;       // $s6
     SPRT          *pIconSprt;       // $s0
@@ -414,7 +412,7 @@ void menu_item_helper_8003B8F0(Actor_MenuMan *work, unsigned int *pOt, int xpos,
     Menu_item_render_frame_rects_8003DBAC(work->field_20_otBuf, xpos, ypos, bBlueBackground);
 }
 
-void menu_8003BBEC(Actor_MenuMan *work)
+void menu_8003BBEC(MenuWork *work)
 {
     Menu_Item_Unknown *temp_v0 = work->field_1DC_menu_item.field_C_alloc;
     int                index;
@@ -461,7 +459,7 @@ void menu_8003BBEC(Actor_MenuMan *work)
 int dword_800AB574 = 0;
 int dword_800AB578 = 0;
 
-int menu_item_update_helper_8003BCD4(Actor_MenuMan *work)
+int menu_item_update_helper_8003BCD4(MenuWork *work)
 {
     int                activeItems;
     int                i;
@@ -573,7 +571,7 @@ int menu_item_update_helper_8003BCD4(Actor_MenuMan *work)
     return 1;
 }
 
-void menu_item_update_helper2_8003BF1C(Actor_MenuMan *work, unsigned int *pOt)
+void menu_item_update_helper2_8003BF1C(MenuWork *work, unsigned int *pOt)
 {
     unsigned short     anim_frame;
     int                anim_frame2;
@@ -1027,7 +1025,7 @@ void menu_item_update_helper4_8003C4EC(void)
     }
 }
 
-void menu_item_update_8003C95C(Actor_MenuMan *work, unsigned int *pOt)
+void menu_item_update_8003C95C(MenuWork *work, unsigned int *pOt)
 {
     GV_PAD         *pPad = work->field_24_pInput;
     Menu_Inventory *pLeftRight;
@@ -1115,7 +1113,7 @@ void menu_item_update_8003C95C(Actor_MenuMan *work, unsigned int *pOt)
     menu_item_update_helper4_8003C4EC();
 }
 
-void sub_8003CB98(Actor_MenuMan *work)
+void sub_8003CB98(MenuWork *work)
 {
     int            field_0_item_id_idx; // $a0
     PANEL_TEXTURE *pItem;               // $v0
@@ -1130,25 +1128,25 @@ void sub_8003CB98(Actor_MenuMan *work)
     }
 }
 
-void menu_item_init_8003CBF0(Actor_MenuMan *menuMan)
+void menu_item_init_8003CBF0(MenuWork *work)
 {
     short val = -1;
 
-    menuMan->field_2C_modules[MENU_ITEM] = (TMenuUpdateFn)menu_item_update_8003C95C;
-    menuMan->field_1DC_menu_item.field_0_current.field_0_id = val;
-    menuMan->field_1DC_menu_item.field_10_state = 0;
-    menuMan->field_1DC_menu_item.field_0_current.field_4_pos = 0;
-    menuMan->field_1DC_menu_item.field_0_current.field_6_current = 1;
-    menuMan->field_1DC_menu_item.field_11 = val;
-    menuMan->field_28_flags |= 4;
+    work->field_2C_modules[MENU_ITEM] = (TMenuUpdateFn)menu_item_update_8003C95C;
+    work->field_1DC_menu_item.field_0_current.field_0_id = val;
+    work->field_1DC_menu_item.field_10_state = 0;
+    work->field_1DC_menu_item.field_0_current.field_4_pos = 0;
+    work->field_1DC_menu_item.field_0_current.field_6_current = 1;
+    work->field_1DC_menu_item.field_11 = val;
+    work->field_28_flags |= 4;
     dword_800ABAD0 = 0;
-    sub_8003D6A8(&menuMan->field_1DC_menu_item, 0, (int *)menu_item_helper_8003B8F0);
+    sub_8003D6A8(&work->field_1DC_menu_item, 0, (int *)menu_item_helper_8003B8F0);
     menu_sub_8003B568();
-    sub_8003CB98(menuMan);
+    sub_8003CB98(work);
     menu_init_nouse_800434A8();
 }
 
-void menu_item_kill_8003CC74(Actor_MenuMan *pMenu)
+void menu_item_kill_8003CC74(MenuWork *work)
 {
-    pMenu->field_28_flags &= ~4u;
+    work->field_28_flags &= ~4u;
 }

--- a/src/Menu/jimaku.c
+++ b/src/Menu/jimaku.c
@@ -13,7 +13,7 @@ extern GV_PAD          GV_PadData_800B05C0[4];
 
 signed char dword_8009E76C[] = {-1, 0, 1, 0, 0, 1, 0, -1};
 
-void menu_jimaku_act_80048FD4( Actor_MenuMan *work, unsigned int *pOt )
+void menu_jimaku_act_80048FD4( MenuWork *work, unsigned int *pOt )
 {
     TextConfig config;
     int        i;

--- a/src/Menu/life.c
+++ b/src/Menu/life.c
@@ -63,7 +63,7 @@ int menu_life_update_helper_8003ECCC(MenuMan_MenuBars *pBars)
     }
 }
 
-void menu_draw_bar_8003ED4C(MenuPrim *pBuffer, long x, long y, long rest, long now, long max, MENU_BAR_CONF *pConfig)
+void menu_draw_bar_8003ED4C(MenuPrim *prim, long x, long y, long rest, long now, long max, MENU_BAR_CONF *bconf)
 {
     TextConfig text_config;
     int        sp28;
@@ -84,9 +84,9 @@ void menu_draw_bar_8003ED4C(MenuPrim *pBuffer, long x, long y, long rest, long n
         return;
     }
 
-    pOt = pBuffer->mPrimBuf.mOt;
+    pOt = prim->mPrimBuf.mOt;
 
-    sp2C = 5 - pConfig->field_A_bar_height;
+    sp2C = 5 - bconf->field_A_bar_height;
     temp_fp = y + 1;
     sp28 = max / 8;
 
@@ -96,7 +96,7 @@ void menu_draw_bar_8003ED4C(MenuPrim *pBuffer, long x, long y, long rest, long n
     text_config.flags = 0;
     text_config.ypos = y + 4;
 
-    if ( !((int)pConfig & 0x80000000) )
+    if ( !((int)bconf & 0x80000000) )
     {
         text_config.colour = 0x643030FF;
     }
@@ -105,10 +105,10 @@ void menu_draw_bar_8003ED4C(MenuPrim *pBuffer, long x, long y, long rest, long n
         text_config.colour = 0x64FFFFFF;
     }
 
-    _menu_number_draw_string_80042BF4(pBuffer, &text_config, pConfig->field_0_text);
+    _menu_number_draw_string_80042BF4(prim, &text_config, bconf->field_0_text);
 
     width = text_config.xpos - temp_v1 + 2;
-    pTile = menu_render_rect_8003DB2C(pBuffer, temp_v1 - 1, text_config.ypos - 1, width, 7, 0);
+    pTile = menu_render_rect_8003DB2C(prim, temp_v1 - 1, text_config.ypos - 1, width, 7, 0);
     setSemiTrans(pTile, 1);
 
     if (rest > max)
@@ -118,7 +118,7 @@ void menu_draw_bar_8003ED4C(MenuPrim *pBuffer, long x, long y, long rest, long n
 
     if (rest > now)
     {
-        _NEW_PRIM(pTile_2, pBuffer);
+        _NEW_PRIM(pTile_2, prim);
 
         setTile(pTile_2);
 
@@ -137,41 +137,41 @@ void menu_draw_bar_8003ED4C(MenuPrim *pBuffer, long x, long y, long rest, long n
         addPrim(pOt, pTile_2);
     }
 
-    _NEW_PRIM(pPoly, pBuffer);
+    _NEW_PRIM(pPoly, prim);
 
     setXYWH(pPoly, x, temp_fp, (now + 7) / 8, sp2C);
 
-    pPoly->r0 = pConfig->field_4_rgb_left[0];
-    pPoly->g0 = pConfig->field_4_rgb_left[1];
-    pPoly->b0 = pConfig->field_4_rgb_left[2];
-    pPoly->r1 = pConfig->field_4_rgb_left[0] + ((pConfig->field_7_rgb_right[0] - pConfig->field_4_rgb_left[0]) * (pPoly->x1 - pPoly->x0)) / 128;
-    pPoly->g1 = pConfig->field_4_rgb_left[1] + ((pConfig->field_7_rgb_right[1] - pConfig->field_4_rgb_left[1]) * (pPoly->x1 - pPoly->x0)) / 128;
-    pPoly->b1 = pConfig->field_4_rgb_left[2] + ((pConfig->field_7_rgb_right[2] - pConfig->field_4_rgb_left[2]) * (pPoly->x1 - pPoly->x0)) / 128;
-    pPoly->r2 = pConfig->field_4_rgb_left[0] + ((pConfig->field_7_rgb_right[0] - pConfig->field_4_rgb_left[0]) * (pPoly->x2 - pPoly->x0)) / 128;
-    pPoly->g2 = pConfig->field_4_rgb_left[1] + ((pConfig->field_7_rgb_right[1] - pConfig->field_4_rgb_left[1]) * (pPoly->x2 - pPoly->x0)) / 128;
-    pPoly->b2 = pConfig->field_4_rgb_left[2] + ((pConfig->field_7_rgb_right[2] - pConfig->field_4_rgb_left[2]) * (pPoly->x2 - pPoly->x0)) / 128;
-    pPoly->r3 = pConfig->field_4_rgb_left[0] + ((pConfig->field_7_rgb_right[0] - pConfig->field_4_rgb_left[0]) * (pPoly->x3 - pPoly->x0)) / 128;
-    pPoly->g3 = pConfig->field_4_rgb_left[1] + ((pConfig->field_7_rgb_right[1] - pConfig->field_4_rgb_left[1]) * (pPoly->x3 - pPoly->x0)) / 128;
-    pPoly->b3 = pConfig->field_4_rgb_left[2] + ((pConfig->field_7_rgb_right[2] - pConfig->field_4_rgb_left[2]) * (pPoly->x3 - pPoly->x0)) / 128;
+    pPoly->r0 = bconf->field_4_rgb_left[0];
+    pPoly->g0 = bconf->field_4_rgb_left[1];
+    pPoly->b0 = bconf->field_4_rgb_left[2];
+    pPoly->r1 = bconf->field_4_rgb_left[0] + ((bconf->field_7_rgb_right[0] - bconf->field_4_rgb_left[0]) * (pPoly->x1 - pPoly->x0)) / 128;
+    pPoly->g1 = bconf->field_4_rgb_left[1] + ((bconf->field_7_rgb_right[1] - bconf->field_4_rgb_left[1]) * (pPoly->x1 - pPoly->x0)) / 128;
+    pPoly->b1 = bconf->field_4_rgb_left[2] + ((bconf->field_7_rgb_right[2] - bconf->field_4_rgb_left[2]) * (pPoly->x1 - pPoly->x0)) / 128;
+    pPoly->r2 = bconf->field_4_rgb_left[0] + ((bconf->field_7_rgb_right[0] - bconf->field_4_rgb_left[0]) * (pPoly->x2 - pPoly->x0)) / 128;
+    pPoly->g2 = bconf->field_4_rgb_left[1] + ((bconf->field_7_rgb_right[1] - bconf->field_4_rgb_left[1]) * (pPoly->x2 - pPoly->x0)) / 128;
+    pPoly->b2 = bconf->field_4_rgb_left[2] + ((bconf->field_7_rgb_right[2] - bconf->field_4_rgb_left[2]) * (pPoly->x2 - pPoly->x0)) / 128;
+    pPoly->r3 = bconf->field_4_rgb_left[0] + ((bconf->field_7_rgb_right[0] - bconf->field_4_rgb_left[0]) * (pPoly->x3 - pPoly->x0)) / 128;
+    pPoly->g3 = bconf->field_4_rgb_left[1] + ((bconf->field_7_rgb_right[1] - bconf->field_4_rgb_left[1]) * (pPoly->x3 - pPoly->x0)) / 128;
+    pPoly->b3 = bconf->field_4_rgb_left[2] + ((bconf->field_7_rgb_right[2] - bconf->field_4_rgb_left[2]) * (pPoly->x3 - pPoly->x0)) / 128;
 
     setPolyG4(pPoly);
     addPrim(pOt, pPoly);
 
-    pTile_3 = menu_render_rect_8003DB2C(pBuffer, x, temp_fp, sp28, sp2C, 0x181800);
+    pTile_3 = menu_render_rect_8003DB2C(prim, x, temp_fp, sp28, sp2C, 0x181800);
     setSemiTrans(pTile_3, 1);
 
-    menu_render_rect_8003DB2C(pBuffer, x - 1, y, 1, sp2C + 2, 0);
-    menu_render_rect_8003DB2C(pBuffer, x, y, sp28, 1, 0);
-    menu_render_rect_8003DB2C(pBuffer, x, y + sp2C + 1, sp28, 1, 0);
-    menu_render_rect_8003DB2C(pBuffer, x + sp28, y, 1, sp2C + 2, 0);
+    menu_render_rect_8003DB2C(prim, x - 1, y, 1, sp2C + 2, 0);
+    menu_render_rect_8003DB2C(prim, x, y, sp28, 1, 0);
+    menu_render_rect_8003DB2C(prim, x, y + sp2C + 1, sp28, 1, 0);
+    menu_render_rect_8003DB2C(prim, x + sp28, y, 1, sp2C + 2, 0);
 
-    _NEW_PRIM(pTpage, pBuffer);
+    _NEW_PRIM(pTpage, prim);
 
     setDrawTPage(pTpage, 1, 1, getTPage(0, 0, 960, 256));
-    addPrim(pBuffer->mPrimBuf.mOt, pTpage);
+    addPrim(prim->mPrimBuf.mOt, pTpage);
 }
 
-void menu_life_update_helper2_8003F30C(MenuPrim *ot, MenuMan_MenuBars *pBars)
+void menu_life_update_helper2_8003F30C(MenuPrim *prim, MenuMan_MenuBars *pBars)
 {
     MENU_BAR_CONF *pBar;
 
@@ -190,7 +190,7 @@ void menu_life_update_helper2_8003F30C(MenuPrim *ot, MenuMan_MenuBars *pBars)
         pBar = UNTAG_PTR(MENU_BAR_CONF, pBar); // pointer flag to make it render in red
     }
 
-    menu_draw_bar_8003ED4C(ot,
+    menu_draw_bar_8003ED4C(prim,
                            pBars->field_2_bar_x,
                            pBars->field_4_bar_y,
                            pBars->field_6_snake_hp,
@@ -200,7 +200,7 @@ void menu_life_update_helper2_8003F30C(MenuPrim *ot, MenuMan_MenuBars *pBars)
 
     if (pBars->field_1_O2_hp)
     {
-        menu_draw_bar_8003ED4C(ot,
+        menu_draw_bar_8003ED4C(prim,
                                pBars->field_2_bar_x,
                                pBars->field_4_bar_y + 12,
                                GM_O2_800ABA34,
@@ -210,19 +210,19 @@ void menu_life_update_helper2_8003F30C(MenuPrim *ot, MenuMan_MenuBars *pBars)
     }
 }
 
-void draw_life_defaultX_8003F408(MenuPrim *ot, int ypos, int a3, int a4, int a5, MENU_BAR_CONF *pConfig)
+void draw_life_defaultX_8003F408(MenuPrim *prim, long y, long rest, long now, long max, MENU_BAR_CONF *bconf)
 {
     GM_GameStatus_800AB3CC |= GAME_FLAG_BIT_16;
-    menu_draw_bar_8003ED4C(ot,
+    menu_draw_bar_8003ED4C(prim,
                            16,
-                           ypos + gSnakeLifeYPos_800ABAF0 - 16,
-                           a3,
-                           a4,
-                           a5,
-                           pConfig);
+                           y + gSnakeLifeYPos_800ABAF0 - 16,
+                           rest,
+                           now,
+                           max,
+                           bconf);
 }
 
-void draw_life_8003F464(MenuPrim *prim, long x, long y, long rest, long now, long max, MENU_BAR_CONF *pBarConfig)
+void draw_life_8003F464(MenuPrim *prim, long x, long y, long rest, long now, long max, MENU_BAR_CONF *bconf)
 {
     GM_GameStatus_800AB3CC |= GAME_FLAG_BIT_16;
     menu_draw_bar_8003ED4C(prim,
@@ -231,7 +231,7 @@ void draw_life_8003F464(MenuPrim *prim, long x, long y, long rest, long now, lon
                            rest,
                            now,
                            max,
-                           pBarConfig);
+                           bconf);
 }
 
 void draw_player_life_8003F4B8(MenuPrim *prim, long x, long y)
@@ -251,7 +251,7 @@ void menu_font_kill_helper_8003F50C(void)
     GM_GameStatus_800AB3CC &= ~GAME_FLAG_BIT_16;
 }
 
-void menu_life_update_8003F530(Actor_MenuMan *work, unsigned char *pOt)
+void menu_life_update_8003F530(MenuWork *work, unsigned char *pOt)
 {
     int               updated;
     MenuMan_MenuBars *pBars;
@@ -354,7 +354,7 @@ void menu_life_update_8003F530(Actor_MenuMan *work, unsigned char *pOt)
     menu_life_update_helper2_8003F30C(work->field_20_otBuf, pBars);
 }
 
-void menu_life_init_8003F7E0(Actor_MenuMan *work)
+void menu_life_init_8003F7E0(MenuWork *work)
 {
     MenuMan_MenuBars *pBar;
 
@@ -371,7 +371,7 @@ void menu_life_init_8003F7E0(Actor_MenuMan *work)
     gSnakeLifeYPos_800ABAF0 = -48;
 }
 
-void menu_life_kill_8003F838(Actor_MenuMan *pMenu)
+void menu_life_kill_8003F838(MenuWork *pMenu)
 {
     pMenu->field_28_flags &= ~1u;
 }
@@ -424,7 +424,7 @@ void sub_8003F97C(char *string)
     font_update_8004695C(&font_800BD968);
 }
 
-void menu_8003F9B4(Actor_MenuMan *work, unsigned int *pOt, const char *str)
+void menu_8003F9B4(MenuWork *work, unsigned int *pOt, const char *str)
 {
     POLY_F4 *polyF4;
     TILE    *tile;
@@ -489,13 +489,13 @@ void menu_8003F9B4(Actor_MenuMan *work, unsigned int *pOt, const char *str)
     }
 }
 
-extern Actor_MenuMan gMenuMan_800BD360;
+extern MenuWork gMenuWork_800BD360;
 
 void menu_font_kill_8003FC0C(void)
 {
   void *ptr;
 
-  gMenuMan_800BD360.field_2B &= ~2;
+  gMenuWork_800BD360.field_2B &= ~2;
   menu_font_kill_helper_8003F50C();
   ptr = font_get_buffer_ptr_80044FE8(&font_800BD968);
   GV_Free_80016230(ptr);

--- a/src/Menu/menuman.c
+++ b/src/Menu/menuman.c
@@ -6,7 +6,7 @@
 #include "libgcl/libgcl.h"
 #include "psyq.h"
 
-extern Actor_MenuMan gMenuMan_800BD360;
+extern MenuWork      gMenuWork_800BD360;
 extern unsigned char gPrimBackingBuffers_800B9360[2][8192];
 
 extern int         GV_Clock_800AB920;
@@ -20,14 +20,14 @@ extern int GM_LoadRequest_800AB3D0;
 extern GV_PAD *GM_CurrentPadData_800AB91C;
 GV_PAD        *GM_CurrentPadData_800AB91C;
 
-void menu_texture_init_8003CC94(Actor_MenuMan *work);
-void menu_radar_init_8003B474(Actor_MenuMan *work);
-void menu_radio_init_80042700(Actor_MenuMan *work);
-void menu_item_init_8003CBF0(Actor_MenuMan *work);
-void menu_weapon_init_8003EC2C(Actor_MenuMan *work);
-void menu_life_init_8003F7E0(Actor_MenuMan *work);
-void menu_number_init_80042848(Actor_MenuMan *work);
-void menu_jimaku_init_800494C4(Actor_MenuMan *work);
+void menu_texture_init_8003CC94(MenuWork *work);
+void menu_radar_init_8003B474(MenuWork *work);
+void menu_radio_init_80042700(MenuWork *work);
+void menu_item_init_8003CBF0(MenuWork *work);
+void menu_weapon_init_8003EC2C(MenuWork *work);
+void menu_life_init_8003F7E0(MenuWork *work);
+void menu_number_init_80042848(MenuWork *work);
+void menu_jimaku_init_800494C4(MenuWork *work);
 
 TInitKillFn gMenuInitFns_8009E290[] = {
     menu_texture_init_8003CC94,
@@ -40,12 +40,12 @@ TInitKillFn gMenuInitFns_8009E290[] = {
     menu_jimaku_init_800494C4,
     NULL};
 
-void menu_radar_kill_8003B554(Actor_MenuMan *work);
-void menu_radio_kill_8004271C(Actor_MenuMan *work);
-void menu_item_kill_8003CC74(Actor_MenuMan *work);
-void menu_weapon_kill_8003ECAC(Actor_MenuMan *work);
-void menu_life_kill_8003F838(Actor_MenuMan *work);
-void menu_number_kill_80042980(Actor_MenuMan *work);
+void menu_radar_kill_8003B554(MenuWork *work);
+void menu_radio_kill_8004271C(MenuWork *work);
+void menu_item_kill_8003CC74(MenuWork *work);
+void menu_weapon_kill_8003ECAC(MenuWork *work);
+void menu_life_kill_8003F838(MenuWork *work);
+void menu_number_kill_80042980(MenuWork *work);
 
 TInitKillFn gMenuKillFns_8009E2B4[] = {
     menu_radar_kill_8003B554,
@@ -59,7 +59,7 @@ TInitKillFn gMenuKillFns_8009E2B4[] = {
 MenuPrim gMenuPrimBuffer_8009E2D0 = {{0, 0, 0}, {0, 0}};
 TextConfig gMenuTextConfig_8009E2E4 = {0, 0, 0, 0x64808080};
 
-void menuman_act_800386A4(Actor_MenuMan *work)
+void menuman_act_800386A4(MenuWork *work)
 {
   unsigned char *pOtStart;
   int            idx_as_flag;
@@ -90,7 +90,7 @@ void menuman_act_800386A4(Actor_MenuMan *work)
   addPrim(pOtStart, &work->field_4C_drawEnv[GV_Clock_800AB920]);
 }
 
-void menuman_kill_800387E8(Actor_MenuMan *work)
+void menuman_kill_800387E8(MenuWork *work)
 {
     TInitKillFn *pIter;
 
@@ -104,16 +104,16 @@ void menuman_kill_800387E8(Actor_MenuMan *work)
     menu_viewer_kill_80044A90(work);
 }
 
-void menu_init_subsystems_8003884C(Actor_MenuMan *pMenuMan)
+void menu_init_subsystems_8003884C(MenuWork *work)
 {
     TInitKillFn *pIter;
     DRAWENV      drawEnv;
 
-    pMenuMan->field_2A_state = 0;
-    pMenuMan->field_29 = 0;
-    pMenuMan->field_28_flags = 0;
+    work->field_2A_state = 0;
+    work->field_29 = 0;
+    work->field_28_flags = 0;
 
-    pMenuMan->field_20_otBuf = &gMenuPrimBuffer_8009E2D0;
+    work->field_20_otBuf = &gMenuPrimBuffer_8009E2D0;
 
     gMenuPrimBuffer_8009E2D0.mPrimPtrs[0] = &gPrimBackingBuffers_800B9360[0][0];
     gMenuPrimBuffer_8009E2D0.mPrimPtrs[1] = &gPrimBackingBuffers_800B9360[1][0];
@@ -121,30 +121,30 @@ void menu_init_subsystems_8003884C(Actor_MenuMan *pMenuMan)
     DG_Init_DrawEnv_80018384(&drawEnv, 0, 0, 320, 224);
     drawEnv.isbg = 0;
     drawEnv.tpage = 31;
-    SetDrawEnv(&pMenuMan->field_4C_drawEnv[0], &drawEnv);
+    SetDrawEnv(&work->field_4C_drawEnv[0], &drawEnv);
 
     DG_Init_DrawEnv_80018384(&drawEnv, 320, 0, 320, 224);
     drawEnv.isbg = 0;
     drawEnv.tpage = 31;
-    SetDrawEnv(&pMenuMan->field_4C_drawEnv[1], &drawEnv);
+    SetDrawEnv(&work->field_4C_drawEnv[1], &drawEnv);
 
     menu_rpk_init_8003DD1C("item");
 
     pIter = &gMenuInitFns_8009E290[0];
     while (*pIter)
     {
-        (*pIter)(pMenuMan);
+        (*pIter)(work);
         pIter++;
     }
 
-    menu_viewer_init_80044A70(pMenuMan);
+    menu_viewer_init_80044A70(work);
 }
 
 void menuman_init_80038954(void)
 {
-    GV_SetNamedActor_8001514C(&gMenuMan_800BD360.actor, (TActorFunction)menuman_act_800386A4,
+    GV_SetNamedActor_8001514C(&gMenuWork_800BD360.actor, (TActorFunction)menuman_act_800386A4,
                               (TActorFunction)menuman_kill_800387E8, "menuman.c");
-    menu_init_subsystems_8003884C(&gMenuMan_800BD360);
+    menu_init_subsystems_8003884C(&gMenuWork_800BD360);
     MENU_InitRadioTable_80049644();
 }
 
@@ -154,12 +154,12 @@ void menuman_Reset_800389A8()
     MENU_ClearRadioTable_8004967C();
     MENU_SetRadarScale_80038E28(4096);
     MENU_SetRadarFunc_80038F30(NULL);
-    gMenuMan_800BD360.field_CC_radar_data.prev_mode = 0;
-    gMenuMan_800BD360.field_CC_radar_data.counter = 0;
-    gMenuMan_800BD360.field_2B = 0;
-    gMenuMan_800BD360.field_1DC_menu_item.field_12_flashingAnimationFrame = 0;
-    gMenuMan_800BD360.field_1F0_menu_weapon.field_12_flashingAnimationFrame = 0;
-    menu_life_init_8003F7E0(&gMenuMan_800BD360);
+    gMenuWork_800BD360.field_CC_radar_data.prev_mode = 0;
+    gMenuWork_800BD360.field_CC_radar_data.counter = 0;
+    gMenuWork_800BD360.field_2B = 0;
+    gMenuWork_800BD360.field_1DC_menu_item.field_12_flashingAnimationFrame = 0;
+    gMenuWork_800BD360.field_1F0_menu_weapon.field_12_flashingAnimationFrame = 0;
+    menu_life_init_8003F7E0(&gMenuWork_800BD360);
 }
 
 void MENU_ResetTexture_80038A00(void)
@@ -169,18 +169,18 @@ void MENU_ResetTexture_80038A00(void)
 
 void MENU_StartDeamon_80038A20(void)
 {
-    GV_InitActor_800150A8(1, &gMenuMan_800BD360.actor, 0);
-    GV_SetNamedActor_8001514C(&gMenuMan_800BD360.actor, 0, 0, "menuman.c");
+    GV_InitActor_800150A8(1, &gMenuWork_800BD360.actor, 0);
+    GV_SetNamedActor_8001514C(&gMenuWork_800BD360.actor, 0, 0, "menuman.c");
 }
 
 void menu_radio_update_helper_80038A6C(void)
 {
-    gMenuMan_800BD360.field_CC_radar_data.display_flag = 1;
+    gMenuWork_800BD360.field_CC_radar_data.display_flag = 1;
 }
 
 void menu_radio_update_helper2_80038A7C(void)
 {
-    gMenuMan_800BD360.field_CC_radar_data.display_flag = 0;
+    gMenuWork_800BD360.field_CC_radar_data.display_flag = 0;
 }
 
 void MENU_ResetSystem_80038A88(void)

--- a/src/Menu/menuman.h
+++ b/src/Menu/menuman.h
@@ -113,12 +113,12 @@ typedef struct array_800BD748_child
 
 void menuman_init_80038954(void);
 
-struct Actor_MenuMan;
+struct MenuWork;
 struct Menu_Inventory;
 struct PANEL;
 struct PANEL_CONF;
 
-typedef void (*PANEL_CONF_update)(struct Actor_MenuMan *, unsigned int *, int, int, struct PANEL *);
+typedef void (*PANEL_CONF_update)(struct MenuWork *, unsigned int *, int, int, struct PANEL *);
 typedef void (*PANEL_CONF_fn2)(struct PANEL_CONF *, int, int*, int*);
 
 typedef struct PANEL_CONF
@@ -210,10 +210,10 @@ typedef struct
     short   counter; // 0x10E
 } RADAR_T;
 
-struct Actor_MenuMan;
+struct MenuWork;
 
-typedef void (*TMenuUpdateFn)(struct Actor_MenuMan *, unsigned char *); // todo
-typedef void (*ButtonStates)(void);                                     // todo
+typedef void (*TMenuUpdateFn)(struct MenuWork *, unsigned char *); // todo
+typedef void (*ButtonStates)(void); // todo
 
 typedef struct MenuPrimBuffer
 {
@@ -268,8 +268,8 @@ typedef struct MenuMan_MenuBars
     short int field_A_k10_decrement;
 } MenuMan_MenuBars;
 
-struct Actor_MenuMan;
-typedef void (*TInitKillFn)(struct Actor_MenuMan *);
+struct MenuWork;
+typedef void (*TInitKillFn)(struct MenuWork *);
 
 enum
 {
@@ -279,7 +279,7 @@ enum
     MENUFLAGS_CAN_OPEN_CODEC = 0x10
 };
 
-enum // Actor_MenuMan->field_2C_modules
+enum // MenuWork->field_2C_modules
 {
     MENU_LIFE = 0,       // Life bars
     MENU_WEAPON = 1,     // Weapons inventory
@@ -294,7 +294,7 @@ enum // Actor_MenuMan->field_2C_modules
 
 typedef unsigned char MenuFlags;
 
-typedef struct             Actor_MenuMan
+typedef struct             MenuWork
 {
     GV_ACT                 actor;
     MenuPrim              *field_20_otBuf;
@@ -318,7 +318,7 @@ typedef struct             Actor_MenuMan
     KCB                   *field_214_font;
     menu_chara_struct     *field_218;
     int                    field_21C;
-} Actor_MenuMan;
+} MenuWork;
 
 // here or jimctl.h?
 typedef struct UnkJimakuStruct // @ 800BDA70
@@ -376,12 +376,12 @@ PANEL_TEXTURE *menu_weapon_get_weapon_rpk_info_8003DED8(int weaponIdx);
 Menu_rpk_item            **menu_rpk_init_8003DD1C(const char *pFileName);
 void                       menu_restore_nouse_80043470();
 PANEL_TEXTURE *menu_rpk_8003B5E0(int idx);
-void         sub_8003CB98(struct Actor_MenuMan *a1);
-int          menu_radio_do_file_mode_8004C418(Actor_MenuMan *work, GV_PAD *pPad);
+void         sub_8003CB98(struct MenuWork *a1);
+int          menu_radio_do_file_mode_8004C418(MenuWork *work, GV_PAD *pPad);
 void         sub_8003CFE0(PANEL_TEXTURE *images, int index);
-void         draw_life_defaultX_8003F408(MenuPrim *ot, int xpos, int ypos, int a4, int a5, MENU_BAR_CONF *pConfig);
-void         draw_life_8003F464(MenuPrim *prim, long x, long y, long rest, long now, long max, MENU_BAR_CONF *pBarConfig);
-void         menu_draw_bar_8003ED4C(MenuPrim *pBuffer, long x, long y, long rest, long now, long max, MENU_BAR_CONF *pConfig);
+void         draw_life_defaultX_8003F408(MenuPrim *prim, long y, long rest, long now, long max, MENU_BAR_CONF *bconf);
+void         draw_life_8003F464(MenuPrim *prim, long x, long y, long rest, long now, long max, MENU_BAR_CONF *bconf);
+void         menu_draw_bar_8003ED4C(MenuPrim *prim, long x, long y, long rest, long now, long max, MENU_BAR_CONF *bconf);
 void         MENU_InitRadioTable_80049644();
 void         set_sprt_default_8004AE14(SPRT *pSprt);
 void         move_coord_8004A494(int *arr, int len);
@@ -401,39 +401,39 @@ void menu_radio_draw_face_helper4_80048868(MenuPrim *prim, menu_chara_struct_sub
 void menu_radio_draw_face_helper5_8004896C(MenuPrim *prim, menu_chara_struct_sub *a2, int idx);
 void menu_radio_draw_face_helper6_800486A0(menu_chara_struct_sub *a1, int idx);
 
-void menu_item_helper_8003B8F0(struct Actor_MenuMan *work, unsigned int *pOt, int xpos, int ypos, Menu_Inventory *pMenuSub);
-void menu_item_update_8003C95C(struct Actor_MenuMan *menuMan, unsigned int *param_2);
-void menu_item_update_helper2_8003BF1C(Actor_MenuMan *work, unsigned int *arg1);
+void menu_item_helper_8003B8F0(struct MenuWork *work, unsigned int *pOt, int xpos, int ypos, Menu_Inventory *pMenuSub);
+void menu_item_update_8003C95C(struct MenuWork *menuMan, unsigned int *param_2);
+void menu_item_update_helper2_8003BF1C(MenuWork *work, unsigned int *arg1);
 void menu_item_update_helper3_8003C24C(Menu_Item_Unknown *, unsigned short);
 void menu_item_update_helper4_8003C4EC();
 void menu_inventory_right_init_items_8003DE50(void);
-void menu_jimaku_act_80048FD4(Actor_MenuMan *work, unsigned int *pOt);
+void menu_jimaku_act_80048FD4(MenuWork *work, unsigned int *pOt);
 void MENU_JimakuWrite_800494E8(char *str, int frames);
 void _menu_number_draw_80042988(MenuPrim *pOt, TextConfig *pSettings, int number);
 void _menu_number_draw_string2_80043220(MenuPrim *pGlue, TextConfig *pTextConfig, const char *str);
 void _menu_number_draw_string_80042BF4(MenuPrim *pGlue, TextConfig *pTextConfig, const char *str);
-void menu_weapon_init_helper_8003E0E8(Actor_MenuMan *param_1, unsigned int *param_2, int param_3, int param_4, PANEL *param_5);
+void menu_weapon_init_helper_8003E0E8(MenuWork *param_1, unsigned int *param_2, int param_3, int param_4, PANEL *param_5);
 void menu_weapon_unknown_8003DEB0(void);
-void menu_weapon_update_8003E990(struct Actor_MenuMan *menuMan, unsigned char *param_2);
+void menu_weapon_update_8003E990(struct MenuWork *menuMan, unsigned char *param_2);
 int  menu_8003DA9C(struct Menu_Inventory *pMenu, GV_PAD *pPad);
 void menu_sub_8003B568(void);
 int  sub_8003DAFC(Menu_Inventory *pLeftRight, GV_PAD *pPad);
 int  sub_8003D52C(void);
 void sub_8003D6CC(Menu_Inventory *pLeftRight, GV_PAD *pPad);
-void sub_8003DA60(struct Actor_MenuMan *work, unsigned int *pOt, Menu_Inventory *pLeftRight, int off1, int off2);
-void menu_viewer_init_80044A70(Actor_MenuMan *);
-void menu_viewer_kill_80044A90(Actor_MenuMan *work);
-void menuman_act_800386A4(Actor_MenuMan *);
-void menuman_kill_800387E8(Actor_MenuMan *);
+void sub_8003DA60(struct MenuWork *work, unsigned int *pOt, Menu_Inventory *pLeftRight, int off1, int off2);
+void menu_viewer_init_80044A70(MenuWork *);
+void menu_viewer_kill_80044A90(MenuWork *work);
+void menuman_act_800386A4(MenuWork *);
+void menuman_kill_800387E8(MenuWork *);
 void sub_8003CE40(PANEL_TEXTURE *, int);
 void sub_8003D6A8(struct Menu_Inventory *pMenuLeft, int bIsRight, void *pUpdateFn);
-void sub_8003EBDC(struct Actor_MenuMan *a1);
+void sub_8003EBDC(struct MenuWork *a1);
 void menu_radio_load_palette_80046B74(void *image, int idx);
 void sub_80046B10(face_anim_image *image, int idx);
 void sub_80046BD8(int idx);
 int sub_80046C90(menu_chara_struct_sub *pSub, int idx, face_full_anim *pFullAnim, int pFrameNum);
 void menuman_Reset_800389A8(void);
-void menu_life_update_8003F530(Actor_MenuMan *work, unsigned char *pOt);
+void menu_life_update_8003F530(MenuWork *work, unsigned char *pOt);
 void draw_player_life_8003F4B8(MenuPrim *prim, long x, long y);
 void init_file_mode_helper_8004A424(int param_1);
 void init_file_mode_helper_helper_80049EDC(void);
@@ -456,7 +456,7 @@ void           MENU_JimakuClear_80049518(void);
 void           MENU_Locate_80038B34(int xpos, int ypos, int flags);
 void           MENU_Color_80038B4C(int r, int g, int b);
 void           menu_radio_codec_start_task_80047C3C(void);
-void           menu_life_init_8003F7E0(Actor_MenuMan *work);
+void           menu_life_init_8003F7E0(MenuWork *work);
 RadioMemory   *menu_radio_table_find_8004D380(int toFind);
 RadioMemory   *menu_radio_table_next_free_8004D3B8(void);
 unsigned char *menu_gcl_read_word_80047098(int *pOut, unsigned char *pScript);
@@ -480,7 +480,7 @@ void           sub_8003F97C(char *param_1);
 void           sub_8004CF20(int code, char **param_2, char **param_3);
 void           sub_80048124(void);
 void           sub_800469F0(menu_chara_struct *pStru);
-void           menu_8003F9B4(Actor_MenuMan *work, unsigned int *pOt, const char *str);
+void           menu_8003F9B4(MenuWork *work, unsigned int *pOt, const char *str);
 void           MENU_DrawBar_80038D74(int xpos, int ypos, int rest, int now, MENU_BAR_CONF *bconf);
 void           MENU_DrawBar2_80038DE0(int ypos, int rest, int now, int max, MENU_BAR_CONF *bconf);
 

--- a/src/Menu/radar.c
+++ b/src/Menu/radar.c
@@ -132,7 +132,7 @@ void MENU_SetRadarFunc_80038F30(TRadarFn_800AB48C func)
     gFn_radar_800AB48C = func;
 }
 
-void draw_radar_vision_cone_80038F3C(Actor_MenuMan *work, char *ot, RADAR_CONE *cone, int x, int y, int color,
+void draw_radar_vision_cone_80038F3C(MenuWork *work, char *ot, RADAR_CONE *cone, int x, int y, int color,
                                      int fadeColor, int scale)
 {
     SVECTOR  right;
@@ -174,7 +174,7 @@ void draw_radar_vision_cone_80038F3C(Actor_MenuMan *work, char *ot, RADAR_CONE *
 }
 
 // Draws the black border around the radar.
-void drawBorder_800390FC(Actor_MenuMan *menuMan, unsigned char *ot)
+void drawBorder_800390FC(MenuWork *menuMan, unsigned char *ot)
 {
     int x1, y1, x2, y2;
 
@@ -219,7 +219,7 @@ extern int dword_800AB9A8[2];
 #define RGB(r, g, b) ((r) | (g << 8) | (b << 16))
 
 // Couldn't test it, but it should be the appropriate function name.
-void drawMap_800391D0(Actor_MenuMan *work, unsigned char *ot, int arg2)
+void drawMap_800391D0(MenuWork *work, unsigned char *ot, int arg2)
 {
     RADAR_CONE cone;
 
@@ -948,7 +948,7 @@ void drawSymbols_8003A978(MenuPrim *prim, int x, int code)
 }
 
 // Slightly misleading name as it also handles the radar in normal mode.
-void drawAlertEvasionJammingPanel_8003AA2C(Actor_MenuMan *work, char *ot, int radarMode, int alertLevel)
+void drawAlertEvasionJammingPanel_8003AA2C(MenuWork *work, char *ot, int radarMode, int alertLevel)
 {
     unsigned int randValue;
     DR_TPAGE    *tpage1;
@@ -1035,7 +1035,7 @@ void menu_init_radar_helper_8003ADAC(void)
     menu_radar_load_rpk_8003AD64();
 }
 
-void menu_radar_helper_8003ADD8(Actor_MenuMan *work, int index)
+void menu_radar_helper_8003ADD8(MenuWork *work, int index)
 {
     DRAWENV drawEnv;
     RADAR_T *radar;
@@ -1071,7 +1071,7 @@ extern int              GM_AlertLevel_800ABA18;
 extern int cons_current_y_800AB4B0;
 int        cons_current_y_800AB4B0;
 
-void draw_radar_8003AEC0(Actor_MenuMan *work, unsigned char *ot)
+void draw_radar_8003AEC0(MenuWork *work, unsigned char *ot)
 {
     int       alertLevel, alertMode;
     DR_AREA  *twin, *twin2, *twin3;
@@ -1213,7 +1213,7 @@ void draw_radar_8003AEC0(Actor_MenuMan *work, unsigned char *ot)
     addPrim(ot, &work->field_CC_radar_data.dr_env[GV_Clock_800AB920]);
 }
 
-void menu_radar_update_8003B350(Actor_MenuMan *work, unsigned char *ot)
+void menu_radar_update_8003B350(MenuWork *work, unsigned char *ot)
 {
   int clipY;
 
@@ -1261,7 +1261,7 @@ void menu_radar_update_8003B350(Actor_MenuMan *work, unsigned char *ot)
 }
 
 
-void menu_radar_init_8003B474(Actor_MenuMan *work)
+void menu_radar_init_8003B474(MenuWork *work)
 {
     unsigned char field_28_flags; // $v1
 
@@ -1282,7 +1282,7 @@ void menu_radar_init_8003B474(Actor_MenuMan *work)
     MENU_SetRadarScale_80038E28(4096);
 }
 
-void menu_radar_kill_8003B554(Actor_MenuMan *work)
+void menu_radar_kill_8003B554(MenuWork *work)
 {
     work->field_28_flags &= ~8u;
 }

--- a/src/Menu/radar.h
+++ b/src/Menu/radar.h
@@ -9,14 +9,14 @@ typedef struct radar_uv // CHARA_TABLE
     unsigned char field_3_h;
 } radar_uv;
 
-typedef void (*TRadarFn_800AB48C)(Actor_MenuMan *, unsigned char *);
+typedef void (*TRadarFn_800AB48C)(MenuWork *, unsigned char *);
 
-void menu_radar_update_8003B350(struct Actor_MenuMan* work, unsigned char * pOt);
+void menu_radar_update_8003B350(MenuWork* work, unsigned char *ot);
 void menu_init_radar_helper_8003ADAC(void);
-void menu_radar_helper_8003ADD8(struct Actor_MenuMan *a1, int a2);
+void menu_radar_helper_8003ADD8(MenuWork *work, int index);
 void MENU_SetRadarFunc_80038F30(TRadarFn_800AB48C func);
 
-void draw_radar_8003AEC0(Actor_MenuMan *work, unsigned char * pOt);
+void draw_radar_8003AEC0(MenuWork *work, unsigned char * pOt);
 void menu_radar_load_rpk_8003AD64();
 
 #endif // _RADAR_H_

--- a/src/Menu/radio.c
+++ b/src/Menu/radio.c
@@ -112,7 +112,7 @@ char menu_string_format_8009E714[] = {
     '\0'
 };
 
-void menu_radio_codec_helper_helper16_8003FC54(Actor_MenuMan *work, unsigned char *pOt, int colour)
+void menu_radio_codec_helper_helper16_8003FC54(MenuWork *work, unsigned char *pOt, int colour)
 {
     TILE     *tile;
     DR_TPAGE *tpage;
@@ -691,7 +691,7 @@ int        SECTION(".sbss") dword_800ABAF8;
 
 extern Radio_8009E664 dword_8009E664[];
 
-void menu_radio_codec_helper_helper14_80040DC4(Actor_MenuMan *work, int param_2)
+void menu_radio_codec_helper_helper14_80040DC4(MenuWork *work, int param_2)
 {
     DR_TPAGE *tpage;
     DR_STP   *stp;
@@ -721,7 +721,7 @@ void menu_radio_codec_helper_helper14_80040DC4(Actor_MenuMan *work, int param_2)
 
 RECT rect_800AB630 = {960, 260, 63, 76};
 
-void init_radio_message_board_80040F74(Actor_MenuMan *work)
+void init_radio_message_board_80040F74(MenuWork *work)
 {
     KCB  local_kcb;
     KCB *allocated_kcb;
@@ -751,7 +751,7 @@ void init_radio_message_board_80040F74(Actor_MenuMan *work)
     }
 }
 
-void menu_radio_codec_helper__helper13_800410E4(Actor_MenuMan *work, char *string)
+void menu_radio_codec_helper__helper13_800410E4(MenuWork *work, char *string)
 {
     KCB *kcb = work->field_214_font;
     dword_800ABB04 = string;
@@ -759,7 +759,7 @@ void menu_radio_codec_helper__helper13_800410E4(Actor_MenuMan *work, char *strin
     font_update_8004695C(kcb);
 }
 
-void sub_80041118(Actor_MenuMan *work)
+void sub_80041118(MenuWork *work)
 {
     KCB *kcb = work->field_214_font;
     dword_800ABB04 = NULL;
@@ -767,7 +767,7 @@ void sub_80041118(Actor_MenuMan *work)
     font_update_8004695C(kcb);
 }
 
-int draw_radio_message_8004114C(Actor_MenuMan *work, unsigned char *pOt)
+int draw_radio_message_8004114C(MenuWork *work, unsigned char *pOt)
 {
     KCB  *kcb;
     SPRT *pPrim;
@@ -796,7 +796,7 @@ int draw_radio_message_8004114C(Actor_MenuMan *work, unsigned char *pOt)
     return 1;
 }
 
-void sub_8004124C(Actor_MenuMan *work)
+void sub_8004124C(MenuWork *work)
 {
     GV_FreeMemory_80015FD0(0, work->field_214_font);
     work->field_214_font = NULL;
@@ -807,7 +807,7 @@ void sub_8004124C(Actor_MenuMan *work)
 // was a new function added in VR?
 // or simply I made a counting mistake and no function was added
 
-int menu_radio_codec_helper_helper12_80041280(Actor_MenuMan *work, unsigned char *pOt, GV_PAD *pPad)
+int menu_radio_codec_helper_helper12_80041280(MenuWork *work, unsigned char *pOt, GV_PAD *pPad)
 {
     menu_chara_struct *pMenuChara;
     KCB               *kcb;
@@ -896,7 +896,7 @@ int menu_radio_codec_helper_helper12_80041280(Actor_MenuMan *work, unsigned char
     return 0;
 }
 
-void draw_radio_wait_mark_8004143C(Actor_MenuMan *work, unsigned char *pOt)
+void draw_radio_wait_mark_8004143C(MenuWork *work, unsigned char *pOt)
 {
     MenuPrim *pOtBuffer; // $v1
     POLY_F3 *pPrim; // $a0
@@ -921,7 +921,7 @@ void draw_radio_wait_mark_8004143C(Actor_MenuMan *work, unsigned char *pOt)
 
 int dword_800AB638 = 14000;
 
-void menu_radio_codec_helper_helper11_8004150C(Actor_MenuMan *work)
+void menu_radio_codec_helper_helper11_8004150C(MenuWork *work)
 {
     int   pRadioCode;
     short dword_800AB638_copy;
@@ -947,7 +947,7 @@ int   dword_800AB63C = 0;
 short word_800AB640 = 0;
 int   dword_800AB644 = -1;
 
-void menu_radio_codec_helper_8004158C(Actor_MenuMan *work, unsigned char *pOt, GV_PAD *pPad)
+void menu_radio_codec_helper_8004158C(MenuWork *work, unsigned char *pOt, GV_PAD *pPad)
 {
     menu_chara_struct *pCharaStruct;
     menu_chara_struct *pCharaStruct2;
@@ -1450,22 +1450,22 @@ skip_helper16:
     addPrim(pOt, tpage2);
 }
 
-void menu_radio_update_helper5_80042160(Actor_MenuMan *menuMan)
+void menu_radio_update_helper5_80042160(MenuWork *work)
 {
     dword_800AB63C = 0;
     dword_800ABB10 = 0;
-    menuMan->field_212 = 8;
-    menuMan->field_210 = 0;
-    menu_radio_codec_create_state_80047CE4(menuMan);
+    work->field_212 = 8;
+    work->field_210 = 0;
+    menu_radio_codec_create_state_80047CE4(work);
 }
 
-void menu_radio_init_nullsub_80042190(Actor_MenuMan *work)
+void menu_radio_init_nullsub_80042190(MenuWork *work)
 {
 }
 
 int dword_800AB648 = 0;
 
-void menu_radio_update_80042198(Actor_MenuMan *work, unsigned char *pOt)
+void menu_radio_update_80042198(MenuWork *work, unsigned char *pOt)
 {
     GCL_ARGS args;
     long     argv[2];
@@ -1624,15 +1624,15 @@ void menu_radio_update_80042198(Actor_MenuMan *work, unsigned char *pOt)
     }
 }
 
-void menu_radio_init_80042700(Actor_MenuMan *pMenu)
+void menu_radio_init_80042700(MenuWork *work)
 {
-    pMenu->field_2C_modules[MENU_RADIO] = menu_radio_update_80042198;
-    pMenu->field_28_flags |= 0x10u;
+    work->field_2C_modules[MENU_RADIO] = menu_radio_update_80042198;
+    work->field_28_flags |= 0x10u;
 }
 
-void menu_radio_kill_8004271C(Actor_MenuMan *pMenu)
+void menu_radio_kill_8004271C(MenuWork *work)
 {
-    pMenu->field_28_flags &= ~0x10u;
+    work->field_28_flags &= ~0x10u;
 }
 
 void menu_RadioCall_80042730(int param_1, int param_2, int time)
@@ -1707,7 +1707,7 @@ RECT SECTION(".sdata") rect_800AB64C[] = {{960, 488, 64, 10}};
 extern SPRT gRadioNumberSprt_800bd9b0;
 extern SPRT gRadioNumberSprt2_800bd9d0;
 
-void menu_number_init_80042848(Actor_MenuMan *work)
+void menu_number_init_80042848(MenuWork *work)
 {
     RECT       rect1, rect2;
     ResHeader *pRes;
@@ -1752,7 +1752,7 @@ void menu_number_init_80042848(Actor_MenuMan *work)
     menu_set_string2_80043138();
 }
 
-void menu_number_kill_80042980(Actor_MenuMan *pMenu)
+void menu_number_kill_80042980(MenuWork *work)
 {
 }
 
@@ -1991,7 +1991,7 @@ void _menu_number_draw_string_80042BF4(MenuPrim *pGlue, TextConfig *pTextConfig,
     pTextConfig->xpos = menu_draw_number_draw_helper_80042B64(pSprt, pGlue->mPrimBuf.mFreeLocation, pTextConfig->xpos, width, pTextConfig->flags);
 }
 
-void menu_number_draw_magazine_80042E38(Actor_MenuMan *work, unsigned int *pOt, int xoff, int yoff, int pMagSize,
+void menu_number_draw_magazine_80042E38(MenuWork *work, unsigned int *pOt, int xoff, int yoff, int pMagSize,
                                         int pAmmo, int pSubCnt2)
 {
     SPRT *sprt;
@@ -2029,7 +2029,7 @@ void menu_number_draw_magazine_80042E38(Actor_MenuMan *work, unsigned int *pOt, 
     }
 }
 
-int menu_number_draw_80042F78(Actor_MenuMan *work, unsigned int *pOt, int xpos, int ypos, int number, int flags)
+int menu_number_draw_80042F78(MenuWork *work, unsigned int *pOt, int xpos, int ypos, int number, int flags)
 {
     TextConfig textConfig; // [sp+10h] [-10h] BYREF
 
@@ -2043,7 +2043,7 @@ int menu_number_draw_80042F78(Actor_MenuMan *work, unsigned int *pOt, int xpos, 
 
 extern SPRT gRadioNumberSprt_800bd9b0;
 
-int menu_number_draw_number2_80042FC0(Actor_MenuMan *work, int xpos, int ypos, int current, int total)
+int menu_number_draw_number2_80042FC0(MenuWork *work, int xpos, int ypos, int current, int total)
 {
     SPRT      *pPrim;
     TextConfig textConfig;
@@ -2069,7 +2069,7 @@ int menu_number_draw_number2_80042FC0(Actor_MenuMan *work, int xpos, int ypos, i
     return textConfig.xpos;
 }
 
-int menu_number_draw_string_800430F0(Actor_MenuMan *work, unsigned int *pOt, int xpos, int ypos, const char *str, int flags)
+int menu_number_draw_string_800430F0(MenuWork *work, unsigned int *pOt, int xpos, int ypos, const char *str, int flags)
 {
     TextConfig textConfig;
 

--- a/src/Menu/radio.h
+++ b/src/Menu/radio.h
@@ -3,12 +3,12 @@
 
 #include "menuman.h"
 
-typedef int (*TUnkRadioFn)(Actor_MenuMan *, unsigned int *); // (work, pOt)
-int menu_draw_mem_debug_80043678(Actor_MenuMan *work, unsigned int *pOt);
-int menu_draw_pow_debug_80043A24(Actor_MenuMan *work, unsigned int *pOt);
-int menu_draw_ply_debug_80043FD0(Actor_MenuMan *work, unsigned int *pOt);
-int menu_draw_obj_debug_800442E4(Actor_MenuMan *work, unsigned int *pOt);
-int menu_draw_tex_debug_800445F8(Actor_MenuMan *work, unsigned int *pOt);
+typedef int (*TUnkRadioFn)(MenuWork *, unsigned int *); // (work, pOt)
+int menu_draw_mem_debug_80043678(MenuWork *work, unsigned int *pOt);
+int menu_draw_pow_debug_80043A24(MenuWork *work, unsigned int *pOt);
+int menu_draw_ply_debug_80043FD0(MenuWork *work, unsigned int *pOt);
+int menu_draw_obj_debug_800442E4(MenuWork *work, unsigned int *pOt);
+int menu_draw_tex_debug_800445F8(MenuWork *work, unsigned int *pOt);
 
 typedef struct RadioIncomingCall // @ 8009E708
 {
@@ -190,16 +190,16 @@ typedef struct ResHeader
 } ResHeader;
 
 void           sub_8004D580(int pressed);
-void           sub_8004124C(Actor_MenuMan *work);
+void           sub_8004124C(MenuWork *work);
 void           menu_radio_update_helper2_80038A7C();
-void           menu_radio_codec_create_state_80047CE4(Actor_MenuMan *menuMan);
-void           menu_radio_update_80042198(Actor_MenuMan *work, unsigned char *pOt);
+void           menu_radio_codec_create_state_80047CE4(MenuWork *menuMan);
+void           menu_radio_update_80042198(MenuWork *work, unsigned char *pOt);
 void menu_800470B4(int idx, menu_chara_struct *pStru, int chara, int code, int faceUnk, int taskWup);
 unsigned char *radio_moveToNext_80047880(menu_chara_struct *unk, unsigned char *pScript);
 void           menu_radio_codec_task_proc_80047AA0(void);
 void           menu_radio_codec_task_proc_helper_80046F3C(menu_chara_struct *pStru, faces_group *pFacesGroup);
 void           menu_radio_compact_free_vars_8004D3D8(void);
-void           init_radio_message_board_80040F74(Actor_MenuMan *work);
+void           init_radio_message_board_80040F74(MenuWork *work);
 void           init_file_mode_8004D24C(DATA_INFO *pSaveMode, int param_2);
 void           sub_800434F4(MenuPrim *pGlue, int param_2, int param_3, PANEL_TEXTURE *param_4);
 void           menu_RadioCall_helper_800403E4();
@@ -211,38 +211,38 @@ void           menu_radio_codec_helper_helper14_helper2_800401AC(MenuPrim *pGlue
 void           menu_radio_codec_helper_helper14_helper6_helper_8004064C(MenuPrim *pGlue, int xpos, int ypos, int colour,
                                                                         int idx);
 int            MENU_GetRadioCode_800497C4(int param_1);
-void           sub_80047D70(Actor_MenuMan *work, int param_2, int pRadioCode);
+void           sub_80047D70(MenuWork *work, int param_2, int pRadioCode);
 void           sub_8004D4A0(RadioCodecStru_800ABB98 *pStru);
 void           menu_radio_update_helper4_8004D2D0(int param_1);
 
-int menu_number_draw_80042F78(Actor_MenuMan *work, unsigned int *pOt, int xpos, int ypos, int number, int flags);
-int menu_number_draw_number2_80042FC0(Actor_MenuMan *work, int xpos, int ypos, int current, int total);
-int menu_number_draw_string_800430F0(Actor_MenuMan *work, unsigned int *pOt, int xpos, int ypos, const char *str, int flags);
+int menu_number_draw_80042F78(MenuWork *work, unsigned int *pOt, int xpos, int ypos, int number, int flags);
+int menu_number_draw_number2_80042FC0(MenuWork *work, int xpos, int ypos, int current, int total);
+int menu_number_draw_string_800430F0(MenuWork *work, unsigned int *pOt, int xpos, int ypos, const char *str, int flags);
 void radio_draw_face_frame_800481CC(MenuPrim *pGlue, int x, int y, int w, int h);
 void menu_draw_nouse_800435A4(MenuPrim *pGlue, int offset_x, int offset_y);
 void menu_draw_frozen_800435C8(MenuPrim *pGlue, int offset_x, int offset_y);
-void menu_number_draw_magazine_80042E38(Actor_MenuMan *work, unsigned int *pOt, int xoff, int yoff, int pMagSize, int pAmmo, int pSubCnt2);
+void menu_number_draw_magazine_80042E38(MenuWork *work, unsigned int *pOt, int xoff, int yoff, int pMagSize, int pAmmo, int pSubCnt2);
 void sub_8004ABF0(int param_1, int param_2, int param_3, int param_4, int divisor);
 void sub_8004B9C4(SELECT_INFO *pStru, int param_2);
 void menu_radio_do_file_mode_helper12_helper_8004B8FC(char *param_1, char *param_2);
 void menu_radio_init_save_mode_8004D280(int param_1, int param_2);
-void menu_radio_update_helper6_80047D40(Actor_MenuMan *work);
+void menu_radio_update_helper6_80047D40(MenuWork *work);
 
-void menu_radio_codec_helper_helper4_8004DE20(Actor_MenuMan *work);
-void menu_radio_codec_helper_helper5_8004D628(Actor_MenuMan *work, unsigned char *pOt);
-int menu_radio_codec_helper_helper2_8004DF68(Actor_MenuMan *work, GV_PAD *pPad);
+void menu_radio_codec_helper_helper4_8004DE20(MenuWork *work);
+void menu_radio_codec_helper_helper5_8004D628(MenuWork *work, unsigned char *pOt);
+int menu_radio_codec_helper_helper2_8004DF68(MenuWork *work, GV_PAD *pPad);
 void menu_radio_codec_helper__helper3_sub_8004DF44();
 void menu_radio_codec_helper_helper_8004E198(int toFind);
 int menu_radio_codec_helper_helper9_80047FF4();
 void menu_radio_codec_state_2_helper_80048024();
-void menu_radio_codec_helper_helper10_80047EFC(Actor_MenuMan *work, int param_2);
+void menu_radio_codec_helper_helper10_80047EFC(MenuWork *work, int param_2);
 void menu_radio_codec_helper_helper8_80048044();
-void menu_radio_codec_helper_helper3_80047F44(Actor_MenuMan *work, int param_2);
+void menu_radio_codec_helper_helper3_80047F44(MenuWork *work, int param_2);
 void menu_radio_codec_helper_helper7_80048080();
 void menu_radio_codec_helper__helper6_80048100();
 void *menu_radio_codec_helper_helper17_80038678();
 int menu_radio_end_check_80048F98();
-void menu_radio_draw_face_80048DB0(Actor_MenuMan *work, menu_chara_struct *chara_struct);
+void menu_radio_draw_face_80048DB0(MenuWork *work, menu_chara_struct *chara_struct);
 
 void sub_8004AEA8(SELECT_INFO *pStru);
 
@@ -252,17 +252,17 @@ int *menu_radio_do_file_mode_helper5_8004ABDC(int idx);
 void menu_radio_do_file_mode_helper4_8004AA68(int idx, int param_2, int param_3, int param_4, int param_5, int divisor);
 void menu_radio_do_file_mode_helper3_8004A994(int idx, int param_2, int param_3, int divisor, SELECT_INFO *field_14);
 int menu_radio_do_file_mode_helper17_8004C2E4(GV_PAD *pPad, int *outParam, SELECT_INFO *pStru);
-void menu_radio_do_file_mode_helper7_8004AE3C(Actor_MenuMan *param_1, const char *str);
-int menu_radio_do_file_mode_helper12_8004BA80(Actor_MenuMan *work, mem_card *pMemcard, const char *param_3, SELECT_INFO *pStru2);
-void menu_radio_do_file_mode_helper14_8004BE98(Actor_MenuMan *work, char *param_2, SELECT_INFO *pStru);
+void menu_radio_do_file_mode_helper7_8004AE3C(MenuWork *param_1, const char *str);
+int menu_radio_do_file_mode_helper12_8004BA80(MenuWork *work, mem_card *pMemcard, const char *param_3, SELECT_INFO *pStru2);
+void menu_radio_do_file_mode_helper14_8004BE98(MenuWork *work, char *param_2, SELECT_INFO *pStru);
 void menu_radio_do_file_mode_helper10_8004B91C(SELECT_INFO *pStru);
-void draw_radio_wait_mark_8004143C(Actor_MenuMan *work, unsigned char *pOt);
-void menu_radio_do_file_mode_helper15_8004C04C(Actor_MenuMan *work, const char **srcs, int cnt, int field_4, const char *field_20, SELECT_INFO *pStru);
+void draw_radio_wait_mark_8004143C(MenuWork *work, unsigned char *pOt);
+void menu_radio_do_file_mode_helper15_8004C04C(MenuWork *work, const char **srcs, int cnt, int field_4, const char *field_20, SELECT_INFO *pStru);
 void menu_radio_do_file_mode_helper16_8004C164(MenuPrim *pGlue, SELECT_INFO *pStru);
 int menu_radio_do_file_mode_helper13_8004BCF8(GV_PAD *pPad, int *pOut, SELECT_INFO *pStru);
-void menu_radio_do_file_mode_helper8_8004AFE4(Actor_MenuMan *work, char *pOt, SELECT_INFO *pStru);
+void menu_radio_do_file_mode_helper8_8004AFE4(MenuWork *work, char *pOt, SELECT_INFO *pStru);
 void menu_radio_do_file_mode_helper6_8004AD40(MenuPrim *pGlue);
-void menu_radio_do_file_mode_save_memcard_8004B0A0(Actor_MenuMan *work, char *pOt, SELECT_INFO *pStru);
+void menu_radio_do_file_mode_save_memcard_8004B0A0(MenuWork *work, char *pOt, SELECT_INFO *pStru);
 void menu_radio_do_file_mode_helper_8004A858();
 void menu_draw_triangle_800435EC(MenuPrim *pGlue, Menu_Triangle *pTriangle);
 

--- a/src/Menu/radiofacedraw.c
+++ b/src/Menu/radiofacedraw.c
@@ -392,7 +392,7 @@ static inline void draw_face_anim(menu_chara_struct_sub *a1, int i, menu_chara_s
     menu_radio_draw_face_helper5_8004896C( prim, a1, i );
 }
 
-void             menu_radio_draw_face_80048DB0( Actor_MenuMan *work, menu_chara_struct *chara_struct )
+void menu_radio_draw_face_80048DB0( MenuWork *work, menu_chara_struct *chara_struct )
 {
     menu_chara_struct_sub *chara_struct_sub;
     MenuPrim              *prim;

--- a/src/Menu/radiomem.c
+++ b/src/Menu/radiomem.c
@@ -141,7 +141,7 @@ void sub_8004D580(int pressed)
     sub_8004D4A0(pStru);
 }
 
-void menu_radio_codec_helper_helper5_8004D628(Actor_MenuMan *pMenuMan, unsigned char *pOt)
+void menu_radio_codec_helper_helper5_8004D628(MenuWork *work, unsigned char *pOt)
 {
     TextConfig config;
     char       buffer[32];
@@ -170,23 +170,23 @@ void menu_radio_codec_helper_helper5_8004D628(Actor_MenuMan *pMenuMan, unsigned 
 
     int temp;
 
-    if ( (pMenuMan->field_212 == 0) && ((GV_Time_800AB330 % 16) >= 5) )
+    if ( (work->field_212 == 0) && ((GV_Time_800AB330 % 16) >= 5) )
     {
         if (stru_800ABB98->field_2 > 0)
         {
-            menu_draw_triangle_800435EC(pMenuMan->field_20_otBuf, &stru_8009EC44);
+            menu_draw_triangle_800435EC(work->field_20_otBuf, &stru_8009EC44);
         }
 
         if ((stru_800ABB98->field_2 + 8) < stru_800ABB98->field_4_count)
         {
-            menu_draw_triangle_800435EC(pMenuMan->field_20_otBuf, &stru_8009EC54);
+            menu_draw_triangle_800435EC(work->field_20_otBuf, &stru_8009EC54);
         }
     }
 
     pCodec = stru_800ABB98;
     temp_s0 = stru_800ABB98->field_2;
     count = stru_800ABB98->field_4_count - stru_800ABB98->field_2;
-    pPrim = pMenuMan->field_20_otBuf;
+    pPrim = work->field_20_otBuf;
 
     if (count > 8)
     {
@@ -289,10 +289,10 @@ void menu_radio_codec_helper_helper5_8004D628(Actor_MenuMan *pMenuMan, unsigned 
         {
             x = 0;
 
-            if (pMenuMan->field_212 > 0)
+            if (work->field_212 > 0)
             {
                 temp = y + 20;
-                y = temp - pMenuMan->field_212 * 5;
+                y = temp - work->field_212 * 5;
             }
             else
             {
@@ -303,7 +303,7 @@ void menu_radio_codec_helper_helper5_8004D628(Actor_MenuMan *pMenuMan, unsigned 
 
     yend = y + 136;
 
-    NEW_PRIM(pLine2, pMenuMan);
+    NEW_PRIM(pLine2, work);
     LSTORE(0x1A1F13, &pLine2->r0);
 
     pLine2->x0 = 75;
@@ -321,7 +321,7 @@ void menu_radio_codec_helper_helper5_8004D628(Actor_MenuMan *pMenuMan, unsigned 
     setLineF4(pLine2);
     addPrim(pOt, pLine2);
 
-    NEW_PRIM(pLine2, pMenuMan);
+    NEW_PRIM(pLine2, work);
     LSTORE(0x1A1F13, &pLine2->r0);
 
     pLine2->x0 = 244;
@@ -341,9 +341,9 @@ void menu_radio_codec_helper_helper5_8004D628(Actor_MenuMan *pMenuMan, unsigned 
 
     if (word_800ABB9C != 0)
     {
-        pMenuMan->field_212 += word_800ABB9C;
+        work->field_212 += word_800ABB9C;
 
-        if ( (pMenuMan->field_212 < 1) || (pMenuMan->field_212 > 4) )
+        if ( (work->field_212 < 1) || (work->field_212 > 4) )
         {
             word_800ABB9C = 0;
         }
@@ -351,7 +351,7 @@ void menu_radio_codec_helper_helper5_8004D628(Actor_MenuMan *pMenuMan, unsigned 
 }
 
 //onwards is definitely radiomem.c
-void menu_radio_codec_helper_helper4_8004DE20(Actor_MenuMan *work)
+void menu_radio_codec_helper_helper4_8004DE20(MenuWork *work)
 {
     RadioCodecStru_800ABB98 *stru_800ABB98_copy;
     RadioMemory             *radioMemoryIter;
@@ -391,7 +391,7 @@ void menu_radio_codec_helper__helper3_sub_8004DF44(void)
     GV_FreeMemory_80015FD0(0, stru_800ABB98);
 }
 
-int menu_radio_codec_helper_helper2_8004DF68(Actor_MenuMan *work, GV_PAD *pPad)
+int menu_radio_codec_helper_helper2_8004DF68(MenuWork *work, GV_PAD *pPad)
 {
     RadioCodecStru_800ABB98 *pStru;
     int                      pressed;

--- a/src/Menu/radiomes.c
+++ b/src/Menu/radiomes.c
@@ -473,27 +473,27 @@ void sub_80047CB4(menu_chara_struct *unknown)
     unknown->field_3C[1].field_0_animState = 0;
 }
 
-void menu_radio_codec_create_state_80047CE4(Actor_MenuMan *pMenuMan)
+void menu_radio_codec_create_state_80047CE4(MenuWork *work)
 {
     menu_chara_struct *pAllocated = GV_AllocMemory_80015EB8(0, sizeof(menu_chara_struct));
     if (!pAllocated)
     {
         printf("no memory\n");
     }
-    pMenuMan->field_218 = pAllocated;
+    work->field_218 = pAllocated;
     dword_800ABB38 = pAllocated;
     sub_80047CB4(pAllocated);
     pAllocated->field_38 = 0;
 }
 
-void menu_radio_update_helper6_80047D40(Actor_MenuMan *work)
+void menu_radio_update_helper6_80047D40(MenuWork *work)
 {
     GV_FreeMemory_80015FD0(0, work->field_218);
     work->field_218 = NULL;
 }
 
 //init from face dat file
-void sub_80047D70(Actor_MenuMan *work, int param_2, int pRadioCode)
+void sub_80047D70(MenuWork *work, int param_2, int pRadioCode)
 {
     menu_chara_struct_sub *pCharaStructSub;
     menu_chara_struct     *pCharaStruct;
@@ -571,7 +571,7 @@ void sub_80047D70(Actor_MenuMan *work, int param_2, int pRadioCode)
     }
 }
 
-void menu_radio_codec_helper_helper10_80047EFC(Actor_MenuMan *work, int param_2)
+void menu_radio_codec_helper_helper10_80047EFC(MenuWork *work, int param_2)
 {
     int                    i;
     menu_chara_struct     *pStru;
@@ -594,7 +594,7 @@ void menu_radio_codec_helper_helper10_80047EFC(Actor_MenuMan *work, int param_2)
     }
 }
 
-void menu_radio_codec_helper_helper3_80047F44(Actor_MenuMan *work, int param_2)
+void menu_radio_codec_helper_helper3_80047F44(MenuWork *work, int param_2)
 {
     int                    i;
     menu_chara_struct     *pStru;

--- a/src/Menu/weapon.c
+++ b/src/Menu/weapon.c
@@ -57,7 +57,7 @@ void sub_8003CC88()
 extern array_800BD748_child array_800BD828[];
 extern array_800BD748_child array_800BD748[];
 
-void menu_texture_init_8003CC94(Actor_MenuMan *work)
+void menu_texture_init_8003CC94(MenuWork *work)
 {
     int                   i, uloop, vloop;
     int                   cy, cy2;
@@ -615,7 +615,7 @@ void sub_8003D6CC(Menu_Inventory *pLeftRight, GV_PAD *pPad)
     }
 }
 
-void menu_8003D7DC(Actor_MenuMan *work, unsigned int *pOt, Menu_Inventory *pSubMenu)
+void menu_8003D7DC(MenuWork *work, unsigned int *pOt, Menu_Inventory *pSubMenu)
 {
     int                field_8, pos, field_C;
     PANEL_CONF        *pPanelConf;
@@ -698,7 +698,7 @@ void menu_8003D7DC(Actor_MenuMan *work, unsigned int *pOt, Menu_Inventory *pSubM
     sub_8003CE84();
 }
 
-void menu_sub_menu_update_8003DA0C(Actor_MenuMan *work, unsigned int *pOt, Menu_Inventory *pSubMenu)
+void menu_sub_menu_update_8003DA0C(MenuWork *work, unsigned int *pOt, Menu_Inventory *pSubMenu)
 {
     if ((GM_GameStatus_800AB3CC & (GAME_FLAG_BIT_06 | GAME_FLAG_BIT_13)) != GAME_FLAG_BIT_06)
     {
@@ -708,7 +708,7 @@ void menu_sub_menu_update_8003DA0C(Actor_MenuMan *work, unsigned int *pOt, Menu_
     }
 }
 
-void sub_8003DA60(Actor_MenuMan *work, unsigned int *pOt, Menu_Inventory *pLeftRight, int off1, int off2)
+void sub_8003DA60(MenuWork *work, unsigned int *pOt, Menu_Inventory *pLeftRight, int off1, int off2)
 {
     pLeftRight->field_8_panel_conf->field_18_pFnUpdate(
         work, pOt, pLeftRight->field_8_panel_conf->field_0_xOffset + off1,
@@ -1034,7 +1034,7 @@ void menu_weapon_update_helper2_helper_8003E030(int wpn_id)
 extern short GM_MagazineMax_800ABA2C;
 extern short GM_Magazine_800AB9EC;
 
-void menu_weapon_init_helper_8003E0E8(Actor_MenuMan *work, unsigned int *pOt, int off_x, int off_y, PANEL *pPanel)
+void menu_weapon_init_helper_8003E0E8(MenuWork *work, unsigned int *pOt, int off_x, int off_y, PANEL *pPanel)
 {
     PANEL_TEXTURE        *pTexture;
     const char           *str;
@@ -1116,7 +1116,7 @@ void menu_weapon_init_helper_8003E0E8(Actor_MenuMan *work, unsigned int *pOt, in
 
 extern short GM_WeaponChanged_800AB9D8;
 
-void menu_weapon_update_helper2_helper2_8003E3B0(Actor_MenuMan *work)
+void menu_weapon_update_helper2_helper2_8003E3B0(MenuWork *work)
 {
     Menu_Item_Unknown *pItemUnknown;
     int                id;
@@ -1163,7 +1163,7 @@ void menu_weapon_update_helper2_helper2_8003E3B0(Actor_MenuMan *work)
 int dword_800AB5E0 = 0;
 int dword_800AB5E4 = 0;
 
-int menu_weapon_update_helper_8003E4B8(Actor_MenuMan *work)
+int menu_weapon_update_helper_8003E4B8(MenuWork *work)
 {
     Menu_Item_Unknown *pPanel;
     int                i;
@@ -1249,7 +1249,7 @@ int menu_weapon_update_helper_8003E4B8(Actor_MenuMan *work)
 extern int DG_UnDrawFrameCount_800AB380;
 extern int GV_PauseLevel_800AB928;
 
-void menu_weapon_update_helper2_8003E674(Actor_MenuMan *work, unsigned int *pOt)
+void menu_weapon_update_helper2_8003E674(MenuWork *work, unsigned int *pOt)
 {
     unsigned short     anim_frame;
     int                anim_frame2;
@@ -1374,15 +1374,15 @@ void menu_weapon_update_helper2_8003E674(Actor_MenuMan *work, unsigned int *pOt)
     }
 }
 
-void menu_weapon_update_8003E990(Actor_MenuMan *menuMan, unsigned char *pOt)
+void menu_weapon_update_8003E990(MenuWork *work, unsigned char *pOt)
 {
     GV_PAD         *pPad;
     Menu_Inventory *pMenu;
     int             selected_id, weapon_id, xoffset;
 
-    pPad = menuMan->field_24_pInput;
+    pPad = work->field_24_pInput;
 
-    if (menuMan->field_2A_state == 0)
+    if (work->field_2A_state == 0)
     {
         if (GM_GameStatus_800AB3CC & (GAME_FLAG_BIT_11 | GAME_FLAG_BIT_20))
         {
@@ -1391,11 +1391,11 @@ void menu_weapon_update_8003E990(Actor_MenuMan *menuMan, unsigned char *pOt)
 
         if (!(GM_PlayerStatus_800ABA50 & 0x20408000))
         {
-            if (menu_8003DA9C(&menuMan->field_1F0_menu_weapon, pPad))
+            if (menu_8003DA9C(&work->field_1F0_menu_weapon, pPad))
             {
-                if (menu_weapon_update_helper_8003E4B8(menuMan))
+                if (menu_weapon_update_helper_8003E4B8(work))
                 {
-                    menuMan->field_2A_state = 1;
+                    work->field_2A_state = 1;
                     GV_PauseLevel_800AB928 |= 4;
                     sub_8003D520();
                 }
@@ -1408,9 +1408,9 @@ void menu_weapon_update_8003E990(Actor_MenuMan *menuMan, unsigned char *pOt)
                 {
                     GM_CurrentWeaponId = WEAPON_NONE;
                 }
-                else if (!sub_8003DF30(menuMan->field_1F0_menu_weapon.field_11))
+                else if (!sub_8003DF30(work->field_1F0_menu_weapon.field_11))
                 {
-                    selected_id = menuMan->field_1F0_menu_weapon.field_11;
+                    selected_id = work->field_1F0_menu_weapon.field_11;
 
                     if (GM_Weapons[selected_id] > WEAPON_NONE)
                     {
@@ -1426,25 +1426,25 @@ void menu_weapon_update_8003E990(Actor_MenuMan *menuMan, unsigned char *pOt)
             }
         }
     }
-    else if (menuMan->field_2A_state == 1)
+    else if (work->field_2A_state == 1)
     {
-        pMenu = &menuMan->field_1F0_menu_weapon;
+        pMenu = &work->field_1F0_menu_weapon;
 
         if (sub_8003DAFC(pMenu, pPad))
         {
-            menuMan->field_1F0_menu_weapon.field_10_state = 3;
+            work->field_1F0_menu_weapon.field_10_state = 3;
         }
         else if (sub_8003D52C() > 255)
         {
             sub_8003D6CC(pMenu, pPad);
 
-            if (menuMan->field_1F0_menu_weapon.field_10_state == 3)
+            if (work->field_1F0_menu_weapon.field_10_state == 3)
             {
-                menuMan->field_1F0_menu_weapon.field_10_state = 2;
+                work->field_1F0_menu_weapon.field_10_state = 2;
             }
         }
     }
-    else if (menuMan->field_2A_state == 4)
+    else if (work->field_2A_state == 4)
     {
         return;
     }
@@ -1456,51 +1456,51 @@ void menu_weapon_update_8003E990(Actor_MenuMan *menuMan, unsigned char *pOt)
 
             if (xoffset < 255)
             {
-                sub_8003DA60(menuMan, (unsigned int *)pOt, &menuMan->field_1F0_menu_weapon, xoffset / 4, 0);
-                menuMan->field_1F0_menu_weapon.field_12_flashingAnimationFrame = 0;
+                sub_8003DA60(work, (unsigned int *)pOt, &work->field_1F0_menu_weapon, xoffset / 4, 0);
+                work->field_1F0_menu_weapon.field_12_flashingAnimationFrame = 0;
             }
         }
         else
         {
-            menuMan->field_1F0_menu_weapon.field_12_flashingAnimationFrame = 0;
+            work->field_1F0_menu_weapon.field_12_flashingAnimationFrame = 0;
         }
 
         return;
     }
 
-    menu_weapon_update_helper2_8003E674(menuMan, (unsigned int *)pOt);
+    menu_weapon_update_helper2_8003E674(work, (unsigned int *)pOt);
 }
 
-void sub_8003EBDC(Actor_MenuMan *menuMan)
+void sub_8003EBDC(MenuWork *work)
 {
     PANEL_TEXTURE *pPanelTex;
     int            weapon_index;
 
-    weapon_index = menuMan->field_1F0_menu_weapon.field_0_current.field_0_id;
-    if (weapon_index != -1 || (weapon_index = menuMan->field_1F0_menu_weapon.field_11) != -1)
+    weapon_index = work->field_1F0_menu_weapon.field_0_current.field_0_id;
+    if (weapon_index != -1 || (weapon_index = work->field_1F0_menu_weapon.field_11) != -1)
     {
         pPanelTex = menu_weapon_get_weapon_rpk_info_8003DED8(weapon_index);
         sub_8003CFE0(pPanelTex, 1);
     }
 }
 
-void menu_weapon_init_8003EC2C(Actor_MenuMan *menuMan)
+void menu_weapon_init_8003EC2C(MenuWork *work)
 {
-    menuMan->field_2C_modules[MENU_WEAPON] = menu_weapon_update_8003E990;
-    menuMan->field_1F0_menu_weapon.field_0_current.field_0_id = -1;
-    menuMan->field_1F0_menu_weapon.field_10_state = 0;
-    menuMan->field_1F0_menu_weapon.field_12_flashingAnimationFrame = 0;
-    menuMan->field_1F0_menu_weapon.field_0_current.field_4_pos = 0;
-    menuMan->field_1F0_menu_weapon.field_0_current.field_6_current = 1;
-    menuMan->field_1F0_menu_weapon.field_11 = -1;
-    menuMan->field_28_flags |= 2;
+    work->field_2C_modules[MENU_WEAPON] = menu_weapon_update_8003E990;
+    work->field_1F0_menu_weapon.field_0_current.field_0_id = -1;
+    work->field_1F0_menu_weapon.field_10_state = 0;
+    work->field_1F0_menu_weapon.field_12_flashingAnimationFrame = 0;
+    work->field_1F0_menu_weapon.field_0_current.field_4_pos = 0;
+    work->field_1F0_menu_weapon.field_0_current.field_6_current = 1;
+    work->field_1F0_menu_weapon.field_11 = -1;
+    work->field_28_flags |= 2;
     dword_800ABAE8 = 0;
-    sub_8003D6A8(&menuMan->field_1F0_menu_weapon, 1, (int *)menu_weapon_init_helper_8003E0E8);
+    sub_8003D6A8(&work->field_1F0_menu_weapon, 1, (int *)menu_weapon_init_helper_8003E0E8);
     menu_inventory_right_init_items_8003DE50();
-    sub_8003EBDC(menuMan);
+    sub_8003EBDC(work);
 }
 
-void menu_weapon_kill_8003ECAC(Actor_MenuMan *work)
+void menu_weapon_kill_8003ECAC(MenuWork *work)
 {
     work->field_28_flags &= ~0x2;
 }

--- a/src/SD/g_sound.h
+++ b/src/SD/g_sound.h
@@ -1,142 +1,245 @@
 #ifndef _G_SOUND_H_
 #define _G_SOUND_H_
 
-#define SE_DUMMY        (  0)
-#define SE_SHOT_01      (  1)   // SOCOM gunshot
-#define SE_STEPL01      (  2)   //
-#define SE_STEPR01      (  3)   //
-#define SE_KARASHT1     (  4)   //
-#define SE_KARASHT      SE_KARASHT1
-#define SE_HOHUKU03     (  5)   // 「ほふく」
-#define SE_CRAWL03      SE_HOHUKU03
-#define SE_HOHUKU04     (  6)   // 「ほふく」
-#define SE_CRAWL04      SE_HOHUKU04
-#define SE_SENAKA01     (  7)   // 「背中」
-#define SE_WALLPRESS    SE_SENAKA01
-#define SE_STAND01      (  8)   // change stance
-#define SE_KAMAE01      (  9)   // 「構える」
-#define SE_READYWEAPON  SE_KAMAE01
-#define SE_HEART01      ( 10)   //
-#define SE_FULL0005     ( 11)   //
-#define SE_KAIHUKU1     ( 12)   // 「回復」 (recover LIFE)
-#define SE_RECOVER_LIFE SE_KAIHUKU1
-#define SE_ITEM0003     ( 13)   // spawn item
-#define SE_RADAR001     ( 14)   // all-clear chime
-#define SE_OVER03       ( 15)   // game over
-#define SE_R_RCV01      ( 16)   // radio CALL (incoming)
-#define SE_PHOTO        ( 17)   // photo shutter
-#define SE_POUT0003     ( 18)   // player out (asphyxiation)
-#define SE_SNEEZE01     ( 19)   //
-#define SE_IDEC03       ( 20)   // "item decide" (equip/unequip)
-#define SE_IDISP02      ( 21)   // "item display" (open window)
-#define SE_IGET01       ( 22)   // "item get" 
-#define SE_ISEL01       ( 23)   // item window move
-#define SE_PDMG01       ( 24)   // player damage (light)
-#define SE_PDMG02       ( 25)   // player damage (heavy)
-#define SE_POUT0001     ( 26)   // player out (normal)
-#define SE_RIFLE01      ( 27)   // PSG-1 gunshot
-#define SE_STEP02       ( 28)   // hop down
-#define SE_MOUSTEP2     ( 29)   //
-#define SE_WSTEP01      ( 30)   // wet step
-#define SE_CUR01        ( 31)   // menu cursor move
-#define SE_WIN01        ( 32)   // menu select
-#define SE_START01      ( 33)   // menu exit
-#define SE_IDEC02       ( 34)   // "item decide" (use medicine)
-#define SE_BUZZER01     ( 35)   // "NO USE" buzzer
-#define SE_ZOOM01       ( 36)   //
-#define SE_ATARU01      ( 37)   // 「あたる」 (hit)
-#define SE_EDMG01       ( 38)   // "enemy damage"
-#define SE_REB01        ( 39)   // bullet ricochet?
-#define SE_REBDRM01     ( 40)   //
-#define SE_EXP_05       ( 41)   // explosion
-#define SE_SIREN0600    ( 42)   // alert siren
-#define SE_BOUND02      ( 43)   // grenade collision
-#define SE_PIN01        ( 44)   // grenade pin
-#define SE_PINNUKI      SE_PIN01
-#define SE_SHOT_E03     ( 45)   // enemy gunshot (FAMAS)
-#define SE_SHOT_E02     ( 46)   // enemy gunshot (gun-camera)
-#define SE_RELOAD01     ( 47)   //
-#define SE_FAMAS01      ( 48)   // player gunshot (FAMAS)
-#define SE_C4PUT01      ( 49)   // C4 placement
-#define SE_C4SW01       ( 50)   // C4 detonator switch
-#define SE_DOWN0002     ( 51)   // (let the bodies) hit the floor
-#define SE_PUNCHIT1     ( 52)   // "punch hit"
-#define SE_KICKHIT1     ( 53)   // "kick hit"
-#define SE_ISEL0003     ( 54)   // "item select" (cursor move)
-#define SE_WALL02       ( 55)   // wall-knock
-#define SE_P_SWING1     ( 56)   // "punch swing"
-#define SE_K_SWING1     ( 57)   // "kick swing"
-#define SE_CHAF0003     ( 58)   // chaff particles
-#define SE_HIBANA01     ( 59)   // 「火花」 (sparks)
-#define SE_UNK060       ( 60)   // also sparks?
-#define SE_UNK061       ( 61)   //
-#define SE_REBGLASS     ( 62)   // broken glass
-#define SE_GLASS11      ( 63)   // glass shatter
-#define SE_UNK064       ( 64)   //
-#define SE_BAKUHA01     ( 65)   // 「爆破」 (blast)
-#define SE_CHAF0002     ( 66)   // chaff explosion
-#define SE_BACKCLS1     ( 67)   // door close (normal)
-#define SE_BACKCLS2     ( 68)   // door close (heavy)
-#define SE_DUMMY_069    ( 69)   //
-#define SE_DUMMY_070    ( 70)   //
-#define SE_DUMMY_071    ( 71)   //
-#define SE_UNK072       ( 72)   //
-#define SE_SHOT_M02     ( 73)   // SOCOM gunshot
-#define SE_FACECHG1     ( 74)   // radio "face change" static
-#define SE_RUN00001     ( 75)   // engine running
-#define SE_NIKITA01     ( 76)   // Nikita missile fired
-#define SE_NIKITA02     ( 77)   // Nikita missile boost
-#define SE_NINJA01      ( 78)   // Ninja stealth effect
-#define SE_UNK079       ( 79)   //
-#define SE_NINJA02      ( 80)   //
-#define SE_HIZA01       ( 81)   // 「ひざ」？ (enemy collapses)
-#define SE_SHOT_SUP     ( 82)   // SOCOM gunshot (suppressed)
-#define SE_EXCLAMATION  ( 83)   // 「びっくりマーク」
-#define SE_R_WINDW1     ( 84)   // radio connect
-#define SE_R_SEL01      ( 85)   // radio select
-#define SE_R_SND01      ( 86)   // radio CALL (outgoing)
-#define SE_R_WINDW2     ( 87)   // radio disconnect
-#define SE_DCLOSE03     ( 88)   // "door close 03"
-#define SE_DCLOSE04     ( 89)   // "door close 04"
-#define SE_DCLOSE05     ( 90)   // "door close 05"
-#define SE_DOPEN03      ( 91)   // "door open 03"
-#define SE_DOPEN04      ( 92)   // "door open 04"
-#define SE_DOPEN05      ( 93)   // "door open 05"
-#define SE_CAMERA07     ( 94)   // surveillance camera (scanning)
-#define SE_CAMERA03     ( 95)   // surveillance camera (lens focus)
-#define SE_BUTTON01     ( 96)   // elevator button
-#define SE_ELECLS03     ( 97)   // "elevator close 03"
-#define SE_ELEOPN03     ( 98)   // "elevator open 03"
-#define SE_SIGHT08      ( 99)   // Wolf's laser sight
-#define SE_INELEV02     (100)   // elevator running
-#define SE_UNK101       (101)   //
-#define SE_START001     (102)   // start/continue gunshot
-#define SE_R_TUNE01     (103)   // radio tuning
-#define SE_R_CANCEL     (104)   // radio cancel
-#define SE_R_CURSOR     (105)   // radio cursor
-#define SE_O2DAMAGE     (106)   // LIFE draining
-#define SE_POUT0002     (107)   // player out (asphyxiation)
-#define SE_R_NOISE1     (108)   // radio static
-#define SE_CAMERA06     (109)   // surveillance camera (jammed)
-#define SE_SHATTR04     (110)   // shutter close
-#define SE_SHATTR06     (111)   // shutter closing
-#define SE_EL_CHM02     (112)   // elevator chime
-#define SE_ELSTOP06     (113)   // elevator stop
-#define SE_MASK0002     (114)   // gas mask breath
-#define SE_RATION01     (115)   // ration unfreeze
-#define SE_SIGNAL02     (116)   //
-#define SE_CLOCK001     (117)   // "tick tick tick"
-#define SE_MMASK001     (118)   //
-#define SE_SIGNAL04     (119)   //
-#define SE_RADAR003     (120)   // radar jammed
-#define SE_JINGLE01     (121)   // jingle (notice)
-#define SE_JINGLE02     (122)   // jingle (strings)
-#define SE_CHR_DSP1     (123)   // (choir aahs)
-#define SE_SHATTR0B     (124)   // shutter close
-#define SE_MENUOPN1     (125)   // ranking menu
-#define SE_KAIHUKU4     (126)   // 「回復」 (LIFE-UP)
-#define SE_LIFE_UP      SE_KAIHUKU4
-#define SE_IDEC04       (127)   // "item decide" (menu toggle)
-#define SE_TBL_MAX      (128)
+#define SE_DUMMY                (  0)
+#define SE_SHOT_01              (  1)
+#define SE_SOCOM_SHOT           SE_SHOT_01
+#define SE_STEPL01              (  2)
+#define SE_STEP_LEFT            SE_STEPL01
+#define SE_STEPR01              (  3)
+#define SE_STEP_RIGHT           SE_STEPR01
+#define SE_KARASHT1             (  4)
+#define SE_KARASHT              SE_KARASHT1
+#define SE_HOHUKU03             (  5)           // ほふく
+#define SE_CRAWL_LEFT           SE_HOHUKU03
+#define SE_HOHUKU04             (  6)           // ほふく
+#define SE_CRAWL_RIGHT          SE_HOHUKU04
+#define SE_SENAKA01             (  7)           // 背中
+#define SE_WALLPRESS            SE_SENAKA01
+#define SE_STAND01              (  8)
+#define SE_CHANGE_STANCE        SE_STAND01
+#define SE_KAMAE01              (  9)           // 構える
+#define SE_READY_WEAPON         SE_KAMAE01
+#define SE_HEART01              ( 10)
+#define SE_HEARTBEAT            SE_HEART01
+#define SE_FULL0005             ( 11)
+#define SE_ITEM_FULL            SE_FULL0005
+#define SE_KAIHUKU1             ( 12)           // 回復
+#define SE_RECOVER_LIFE         SE_KAIHUKU1
+#define SE_ITEM0003             ( 13)
+#define SE_SPAWN_ITEM           SE_ITEM0003
+#define SE_RADAR001             ( 14)
+#define SE_RADAR_CHIME          SE_RADAR001     // all-clear chime
+#define SE_OVER03               ( 15)
+#define SE_GAMEOVER             SE_OVER03
+#define SE_R_RCV01              ( 16)
+#define SE_RADIO_INCOMING       SE_R_RCV01
+#define SE_PHOTO01              ( 17)
+#define SE_PHOTO_SHUTTER        SE_PHOTO01
+#define SE_POUT0003             ( 18)
+#define SE_PLAYEROUT_GAS        SE_POUT0003     // asphyxiation
+#define SE_SNEEZE01             ( 19)
+#define SE_SNEEZE               SE_SNEEZE01
+#define SE_IDEC03               ( 20)
+#define SE_ITEM_EQUIP           SE_IDEC03
+#define SE_IDISP02              ( 21)
+#define SE_ITEM_OPENWINDOW      SE_IDISP02
+#define SE_IGET01               ( 22)
+#define SE_ITEM_GET             SE_IGET01
+#define SE_ISEL01               ( 23)
+#define SE_ITEM_SELECT          SE_ISEL01
+#define SE_PDMG01               ( 24)
+#define SE_PLAYER_DAMAGE_LIGHT  SE_PDMG01
+#define SE_PDMG02               ( 25)
+#define SE_PLAYER_DAMAGE_HEAVY  SE_PDMG02
+#define SE_POUT0001             ( 26)
+#define SE_PLAYEROUT            SE_POUT0001
+#define SE_RIFLE01              ( 27)
+#define SE_PSG1_SHOT            SE_RIFLE01
+#define SE_STEP02               ( 28)
+#define SE_HOP_DOWN             SE_STEP02
+#define SE_MOUSTEP2             ( 29)
+#define SE_WSTEP01              ( 30)
+#define SE_WET_STEP             SE_WSTEP01
+#define SE_CUR01                ( 31)
+#define SE_MENU_CURSOR          SE_CUR01
+#define SE_WIN01                ( 32)
+#define SE_MENU_SELECT          SE_WIN01
+#define SE_START01              ( 33)
+#define SE_MENU_EXIT            SE_START01
+#define SE_IDEC02               ( 34)
+#define SE_ITEM_MEDICINE        SE_IDEC02
+#define SE_BUZZER01             ( 35)
+#define SE_BUZZER               SE_BUZZER01
+#define SE_ZOOM01               ( 36)
+#define SE_SCOPE_ZOOM           SE_ZOOM01
+#define SE_ATARU01              ( 37)           // あたる
+#define SE_HIT                  SE_ATARU01
+#define SE_EDMG01               ( 38)
+#define SE_ENEMY_DAMAGE         SE_EDMG01
+#define SE_REB01                ( 39)           // ricochet?
+#define SE_REBDRM01             ( 40)           // ricochet?
+#define SE_EXP_05               ( 41)
+#define SE_EXPLOSION            SE_EXP_05
+#define SE_SIREN0600            ( 42)
+#define SE_ALERT_SIREN          SE_SIREN0600
+#define SE_BOUND02              ( 43)
+#define SE_GRENADE_HIT          SE_BOUND02
+#define SE_PIN01                ( 44)           // grenade pin
+#define SE_PINNUKI              SE_PIN01
+#define SE_SHOT_E03             ( 45)
+#define SE_ENEMY_SHOT           SE_SHOT_E03
+#define SE_SHOT_E02             ( 46)
+#define SE_GUNCAM_SHOT          SE_SHOT_E02
+#define SE_RELOAD01             ( 47)
+#define SE_RELOAD               SE_RELOAD01
+#define SE_FAMAS01              ( 48)
+#define SE_FAMAS_SHOT           SE_FAMAS01
+#define SE_C4PUT01              ( 49)
+#define SE_C4_PUT               SE_C4PUT01
+#define SE_C4SW01               ( 50)
+#define SE_C4_SWITCH            SE_C4SW01
+#define SE_DOWN0002             ( 51)
+#define SE_HIT_FLOOR            SE_DOWN0002
+#define SE_PUNCHIT1             ( 52)
+#define SE_PUNCH_HIT            SE_PUNCHIT1
+#define SE_KICKHIT1             ( 53)
+#define SE_KICK_HIT             SE_KICKHIT1
+#define SE_ISEL0003             ( 54)
+#define SE_ITEM_CURSOR          SE_ISEL0003
+#define SE_WALL02               ( 55)
+#define SE_WALLKNOCK            SE_WALL02
+#define SE_P_SWING1             ( 56)
+#define SE_PUNCH_SWING          SE_P_SWING1
+#define SE_K_SWING1             ( 57)
+#define SE_KICK_SWING           SE_K_SWING1
+#define SE_CHAF0003             ( 58)
+#define SE_CHAFF_PARTICLE       SE_CHAF0003
+#define SE_HIBANA01             ( 59)           // 火花
+#define SE_SPARKS               SE_HIBANA01
+#define SE_PANEL01              ( 60)
+#define SE_ELECTRIC_PANEL       SE_PANEL01
+#define SE_UNK061               ( 61)
+#define SE_REBGLASS             ( 62)
+#define SE_BROKEN_GLASS         SE_REBGLASS
+#define SE_GLASS11              ( 63)
+#define SE_GLASS_SHATTER        SE_GLASS11
+#define SE_UNK064               ( 64)
+#define SE_BAKUHA01             ( 65)           // 爆破
+#define SE_BLAST                SE_BAKUHA01
+#define SE_CHAF0002             ( 66)
+#define SE_CHAFF_EXPLODE        SE_CHAF0002
+#define SE_BACKCLS1             ( 67)
+#define SE_DOOR_CLOSE_NORMAL    SE_BACKCLS1
+#define SE_BACKCLS2             ( 68)
+#define SE_DOOR_CLOSE_HEAVY     SE_BACKCLS2
+#define SE_DUMMY_069            ( 69)           // (reserved)
+#define SE_DUMMY_070            ( 70)           // (reserved)
+#define SE_DUMMY_071            ( 71)           // (reserved)
+#define SE_UNK072               ( 72)
+#define SE_SHOT_M02             ( 73)
+#define SE_SOCOM_SHOT2          SE_SHOT_M02
+#define SE_FACECHG1             ( 74)
+#define SE_RADIO_FACECHANGE     SE_FACECHG1
+#define SE_RUN00001             ( 75)
+#define SE_RUNNING_ENGINE       SE_RUN00001
+#define SE_NIKITA01             ( 76)
+#define SE_NIKITA_FIRED         SE_NIKITA01
+#define SE_NIKITA02             ( 77)
+#define SE_NIKITA_BOOST         SE_NIKITA02
+#define SE_NINJA01              ( 78)
+#define SE_NINJA_STEALTH        SE_NINJA01
+#define SE_LOCKON1              ( 79)
+#define SE_STINGER_LOCKON       SE_LOCKON1
+#define SE_NINJA02              ( 80)
+#define SE_HIZA01               ( 81)
+#define SE_ENEMY_COLLAPSE       SE_HIZA01
+#define SE_SHOT_S01             ( 82)
+#define SE_SOCOM_SUPPRESSED     SE_SHOT_S01
+#define SE_BIKKURI              ( 83)           // びっくりマーク
+#define SE_EXCLAMATION          SE_BIKKURI      // "!"
+#define SE_R_WINDW1             ( 84)
+#define SE_RADIO_CONNECT        SE_R_WINDW1
+#define SE_R_SEL01              ( 85)
+#define SE_RADIO_SELECT         SE_R_SEL01
+#define SE_R_SND01              ( 86)
+#define SE_RADIO_SEND           SE_R_SND01
+#define SE_R_WINDW2             ( 87)
+#define SE_RADIO_DISCONNECT     SE_R_WINDW2
+#define SE_DCLOSE03             ( 88)
+#define SE_DOOR_CLOSE3          SE_DCLOSE03
+#define SE_DCLOSE04             ( 89)
+#define SE_DOOR_CLOSE4          SE_DCLOSE04
+#define SE_DCLOSE05             ( 90)
+#define SE_DOOR_CLOSE5          SE_DCLOSE05
+#define SE_DOPEN03              ( 91)
+#define SE_DOOR_OPEN3           SE_DOPEN03
+#define SE_DOPEN04              ( 92)
+#define SE_DOOR_OPEN4           SE_DOPEN04
+#define SE_DOPEN05              ( 93)
+#define SE_DOOR_OPEN5           SE_DOPEN05
+#define SE_CAMERA07             ( 94)
+#define SE_CAMERA_SCAN          SE_CAMERA07
+#define SE_CAMERA03             ( 95)
+#define SE_CAMERA_LENS          SE_CAMERA03
+#define SE_BUTTON01             ( 96)
+#define SE_ELEVATOR_BUTTON      SE_BUTTON01
+#define SE_ELECLS03             ( 97)
+#define SE_ELEVATOR_CLOSE       SE_ELECLS03
+#define SE_ELEOPN03             ( 98)
+#define SE_ELEVATOR_OPEN        SE_ELEOPN03
+#define SE_SIGHT08              ( 99)
+#define SE_LASER_SIGHT          SE_SIGHT08      // Wolf's laser sight
+#define SE_INELEV02             (100)
+#define SE_ELEVATOR_RUNNING     SE_INELEV02
+#define SE_SHOT_S02             (101)
+#define SE_MP5_SHOT             SE_SHOT_S02
+#define SE_START001             (102)
+#define SE_MENU_GUNSHOT         SE_START001
+#define SE_R_TUNE01             (103)
+#define SE_RADIO_TUNING         SE_R_TUNE01
+#define SE_R_CANCEL             (104)
+#define SE_RADIO_CANCEL         SE_R_CANCEL
+#define SE_R_CURSOR             (105)
+#define SE_RADIO_CURSOR         SE_R_CURSOR
+#define SE_O2DAMAGE             (106)
+#define SE_POUT0002             (107)
+#define SE_PLAYEROUT_GAS2       SE_POUT0002     // asphyxiation
+#define SE_R_NOISE1             (108)
+#define SE_RADIO_STATIC         SE_R_NOISE1
+#define SE_CAMERA06             (109)
+#define SE_CAMERA_JAMMED        SE_CAMERA06
+#define SE_SHATTR04             (110)
+#define SE_SHUTTER_CLOSE        SE_SHATTR04
+#define SE_SHATTR06             (111)
+#define SE_SHUTTER_CLOSING      SE_SHATTR06
+#define SE_EL_CHM02             (112)
+#define SE_ELEVATOR_CHIME       SE_EL_CHM02
+#define SE_ELSTOP06             (113)
+#define SE_ELEVATOR_STOP        SE_ELSTOP06
+#define SE_MASK0002             (114)
+#define SE_GASMASK_BREATH       SE_MASK0002
+#define SE_RATION01             (115)
+#define SE_RATION_UNFREEZE      SE_RATION01
+#define SE_SIGNAL02             (116)
+#define SE_CLOCK001             (117)
+#define SE_TIMEBOMB_TICK        SE_CLOCK001
+#define SE_MMASK001             (118)
+#define SE_SIGNAL04             (119)
+#define SE_RADAR003             (120)
+#define SE_RADAR_JAMMED         SE_RADAR003
+#define SE_JINGLE01             (121)           // "notice" jingle
+#define SE_JINGLE02             (122)           // "strings" jingle
+#define SE_CHR_DSP1             (123)
+#define SE_LOGO_CHOIR           SE_CHR_DSP1
+#define SE_SHATTR0B             (124)
+#define SE_SHUTTER_CLOSE2       SE_SHATTR0B
+#define SE_MENUOPN1             (125)
+#define SE_MENU_RANKING         SE_MENUOPN1
+#define SE_KAIHUKU4             (126)           // 回復
+#define SE_LIFE_UP              SE_KAIHUKU4
+#define SE_IDEC04               (127)
+#define SE_MENU_TOGGLE          SE_IDEC04
+#define SE_TBL_MAX              (128)
 
 #endif // _G_SOUND_H_

--- a/src/SD/sd_cli.c
+++ b/src/SD/sd_cli.c
@@ -1,19 +1,12 @@
+#include "SD/sd_incl.h"
+#include "SD/sd_ext.h"
+
 #include "linker.h"
 #include "psyq.h"
 #include "mts/mts_new.h"
 #include "mts/taskid.h"
-#include "SD/sound.h"
-#include "SD/sd_incl.h"
 
-extern int dword_8009F7B4; /* in sd_str.c */
-
-extern char         byte_800C0468[];
-extern unsigned int song_end_800C04E8;
-extern unsigned int sng_play_code_800C04F8;
-extern volatile int sd_task_status_800C0BFC;
-extern unsigned int str_status_800BF16C;
-extern int          sng_status_800BF158;
-extern SEPLAYTBL    se_playing_800BF068[8];
+extern SETBL *se_exp_table_800C0520;
 
 int sd_task_active_800886C4(void)
 {
@@ -121,15 +114,6 @@ void stop_xa_sd_800888B4(void)
     SpuSetCommonAttr(&c_attr);
     printf("***XA Sound Stop***\n");
 }
-
-extern SETBL        se_tbl_800A22C4[128];
-extern int          se_tracks_800BF004;
-extern SEPLAYTBL    se_playing_800BF068[8];
-extern SETBL       *se_exp_table_800C0520;
-
-extern char     *se_header_800BF284;
-extern int       stop_jouchuu_se_800BF1A0;
-extern SEPLAYTBL se_request_800BF0E0[8];
 
 int SePlay_800888F8(int sound_code)
 {
@@ -268,28 +252,6 @@ int get_str_counter_80088CA0(void)
 {
     return dword_8009F7B4;
 }
-
-extern int stop_jouchuu_se_800BF1A0;
-
-extern int dword_800BF000;
-extern int str_fadein_fg_800C04EC;
-extern int str_vox_on_800BF160;
-extern int str_fout_fg_800BF26C;
-extern int sound_mono_fg_800C050C;
-extern int str_fade_time_800C04F4;
-extern int dword_800C0410;
-extern unsigned int dword_800BF27C;
-extern unsigned int str_status_800BF16C;
-extern unsigned int str_fade_value_800C0584;
-extern int str_load_code_800C04F0;
-extern int se_rev_on_800C0574;
-extern int sd_sng_code_buf_800BF018[16];
-extern int bgm_idx_800BF1E8;
-extern int vox_rev_on_800BF144;
-extern int se_load_code_800BF28C;
-extern int wave_load_code_800C0528;
-extern int wave_save_code_800C0578;
-extern int dword_800BEFFC;
 
 void sd_set_80088CB0(int sound_code)
 {

--- a/src/SD/sd_drv.c
+++ b/src/SD/sd_drv.c
@@ -1,76 +1,8 @@
-#include "SD/sound.h"
 #include "SD/sd_incl.h"
+#include "SD/sd_ext.h"
+
 #include "mts/mts_new.h"
 #include "mts/taskid.h"
-
-extern int sng_status_800BF158;
-extern int sng_fout_term_800C0518;
-extern int sng_fade_time_800C0430[14];
-extern int sng_fadein_time_800BF05C;
-extern unsigned int mtrack_800BF1EC;
-extern SOUND_W* sptr_800C057C;
-extern int keyons_800BF260;
-extern int keyoffs_800BF29C;
-extern SOUND_W sound_w_800BF2A8[21];
-extern unsigned int sng_play_code_800C04F8;
-extern int sng_load_code_800C0428;
-extern unsigned char *sng_data_800C0420;
-extern int sng_fp_800BF1D8;
-extern int sng_fade_in_2_800C0BC0;
-extern int sng_kaihi_fg_800BF290;
-
-extern int sd_sng_code_buf_800BF018[16];
-extern int sng_syukan_fg_800C0510;
-extern int sng_pause_fg_800BF298;
-extern int sng_fout_fg_800BF25C;
-extern int sng_fadein_fg_800C041C;
-extern int song_end_800C04E8;
-extern int se_tracks_800BF004;
-extern int keyd_800C0524;
-extern int sd_code_read_800BF288;
-extern int stop_jouchuu_se_800BF1A0;
-extern int dword_800BEFF8;
-extern int se_rev_on_800C0574;
-extern int dword_800BF064;
-extern int dword_800BF210;
-
-extern int dword_800C0580;
-extern int dword_800BF154;
-extern int dword_800BF008;
-
-extern unsigned int   str_status_800BF16C;
-extern unsigned int   mtrack_800BF1EC;
-extern unsigned char *mptr_800C0570;
-
-extern int spu_ch_tbl_800A2AC8[]; /* in sd_wk.c */
-extern int sng_master_vol_800C0BC8[13];
-extern int sng_fade_time_800C0430[14];
-extern int sng_fade_value_800C0538[13];
-
-extern int se_vol_800BF1F0[8];
-extern int se_pan_800BF1B8[8];
-
-extern SOUND_W * sptr_800C057C;
-extern SOUND_W   sound_w_800BF2A8[21];
-extern SEPLAYTBL se_request_800BF0E0[8];
-extern SEPLAYTBL se_playing_800BF068[8];
-
-void sng_track_init_800859B8(SOUND_W *ptr);
-void SD_80085480(void);
-void sng_pause_80087EF4(void);
-void sng_pause_off_80087F24(void);
-void SD_SongFadeIn_80084CCC(unsigned int mode);
-int  SngFadeOutP_80084D60(unsigned int a1);
-int  SD_SongFadeoutAndStop_80084E48(unsigned int code);
-int  SD_SongKaihiMode_80084F88(void);
-void sng_off_80087E2C(void);
-void sng_adrs_set_80085658(int idx);
-void SngFadeWkSet_80085020(void);
-void SD_80085164(void);
-int  sound_sub_80085A50(void);
-void se_off_80087E94(int i);
-void se_adrs_set_8008576C(int idx);
-void spuwr_80087A88(void);
 
 void IntSdMain_80084494(void)
 {

--- a/src/SD/sd_ext.h
+++ b/src/SD/sd_ext.h
@@ -179,8 +179,8 @@ extern unsigned char dummy_data_800A2D28[4096];
 /*---------------------------------------------------------------------------*/
 #ifndef __BSSDEFINE__
 
-extern  unsigned long   sd_main_stack_800BE7C8[512];
-extern  unsigned long   sd_int_stack_800BEFC8;
+extern  unsigned int    sd_main_stack_800BE7C8[512]; /* unsigned long */
+extern  unsigned int    sd_int_stack_800BEFC8; /* unsigned long */
 extern  int             dword_800BEFCC;
 
 extern  int             sd_debug_800BEFD4;
@@ -198,7 +198,7 @@ extern  int             dword_800BF000;
 extern  int             se_tracks_800BF004;
 
 extern  int             dword_800BF008;
-extern  unsigned long   blank_data_addr_800BF00C;
+extern  unsigned int    blank_data_addr_800BF00C; /* unsigned long */
 extern  char           *cdload_buf_800BF010; /* unsigned char * */
 extern  int             se_fp_800BF014;
 extern  int             sd_sng_code_buf_800BF018[16];
@@ -214,7 +214,7 @@ extern  unsigned long   mdata2_800BF0D4;
 extern  unsigned long   mdata3_800BF0D8;
 extern  unsigned long   mdata4_800BF0DC;
 extern  SEPLAYTBL       se_request_800BF0E0[8];
-extern  unsigned long   spu_load_offset_800BF140;
+extern  unsigned int    spu_load_offset_800BF140; /* unsigned long */
 extern  int             vox_rev_on_800BF144;
 
 extern  int             dword_800BF154;
@@ -251,13 +251,13 @@ extern  int             str_off_idx_800BF264;
 extern  int             str_mono_fg_800BF268;
 extern  int             str_fout_fg_800BF26C;
 extern  int             dword_800BF270;
-extern  unsigned long   wave_unload_size_800BF274;
+extern  unsigned int    wave_unload_size_800BF274; /* unsigned long */
 extern  int             str_mute_off_idx;
 extern  unsigned int    dword_800BF27C;
 extern  int             str_trans_offset;
 extern  char           *se_header_800BF284; /* struct SETBL* */
 extern  int             sd_code_read_800BF288;
-extern  unsigned long   se_load_code_800BF28C;
+extern  unsigned int    se_load_code_800BF28C; /* unsigned long */
 extern  int             sng_kaihi_fg_800BF290;
 extern  int             wave_data_800BF294;
 extern  int             sng_pause_fg_800BF298;
@@ -276,7 +276,7 @@ extern  int             sng_load_code_800C0428;
 
 extern  int             sng_fade_time_800C0430[14];
 extern  char            byte_800C0468[128];
-extern  unsigned long   song_end_800C04E8;
+extern  unsigned int    song_end_800C04E8; /* unsigned long */
 extern  int             str_fadein_fg_800C04EC;
 extern  int             str_load_code_800C04F0;
 extern  int             str_fade_time_800C04F4;
@@ -293,8 +293,8 @@ extern  int             str_wave_size_800C051C;
 // extern  unsigned char  *se_exp_table_800C0520;
 // extern  SETBL          *se_exp_table_800C0520;
 extern  unsigned long   keyd_800C0524;
-extern  unsigned long   wave_load_code_800C0528;
-extern  unsigned long   spu_wave_start_ptr_800C052C;
+extern  unsigned int    wave_load_code_800C0528; /* unsigned long */
+extern  unsigned int    spu_wave_start_ptr_800C052C; /* unsigned long */
 extern  WAVE_W         *voice_tbl_800C0530;
 
 extern  int             sng_fade_value_800C0538[13];

--- a/src/SD/sd_ext.h
+++ b/src/SD/sd_ext.h
@@ -1,0 +1,321 @@
+#ifndef _SD_EXT_H_
+#define _SD_EXT_H_
+
+#include <libspu.h>
+#include "sd_incl.h"
+
+/*---------------------------------------------------------------------------*/
+// do not #include this file externally! use sound.h instead.
+
+/* sd_main.c */
+void sound_main_80081910(int argc, const char *argv[]);
+void nullsub_7_80081A10(int *arg0, int arg1, int arg2);
+void SdMain_80081A18(void);
+void SdInt_80081BDC(void);
+void sd_init_80081C7C(void);
+void SdTerm_80081F8C(void);
+void keyOff_80081FC4(unsigned int ch);
+void KeyOffStr_80081FE8(void);
+void sub_800820EC(void);
+void keyOn_80082170(unsigned int ch);
+int sd_mem_alloc_80082194(void);
+
+/* sd_str.c */
+extern int dword_8009F7B4;
+extern char *dword_8009F7B8;
+
+void StrFadeIn_800822C8(unsigned int arg0);
+int StrFadeOut_80082310(unsigned int arg0);
+int StrFadeOutStop_80082380(unsigned int fadeSpeed);
+int StartStream_80082448(void);
+void UserSpuIRQProc_80082640(void);
+void sub_8008279C(void);
+void SD_nullsub_20_800827A4(void);
+int StrSpuTransWithNoLoop_800827AC(void);
+void StrSpuTransClose_80083394(void);
+void StrSpuTrans_800833FC(void);
+
+/* sd_file.c */
+int SD_LoadSeFile_8008341C(void);
+int SD_LoadWaveFile_800834FC(void);
+void WaveCdLoad_80083804(void);
+void WaveSpuTrans_80083944(void);
+int SD_SongLoadData_8008394C(int a1, int a2);
+int SD_80083954(int a1, unsigned char *a2, int a3);
+int SD_8008395C(int a1, int a2);
+void StrFadeWkSet_80083964(void);
+int StrFadeInt_800839C8(void);
+void code2name_80083BB4(unsigned int code, char *name);
+char num2char_80083E68(unsigned int num);
+unsigned char *SD_SngDataLoadInit_80083E8C(unsigned short unused);
+void SD_80083ED4(void);
+unsigned char *SD_80083EE8(unsigned short unused);
+void SD_80083EF8(void);
+char *LoadInit_80083F08(unsigned short unused);
+int SD_80083F54(char *end);
+char *SD_WavLoadBuf_800841D4(char *arg0);
+void SD_Unload_800843BC(void);
+
+/* sd_drv.c */
+void IntSdMain_80084494(void);
+void SD_SongFadeIn_80084CCC(unsigned int mode);
+int SngFadeOutP_80084D60(unsigned int code);
+int SD_SongFadeoutAndStop_80084E48(unsigned int code);
+int SD_SongKaihiMode_80084F88(void);
+void SngFadeWkSet_80085020(void);
+void SD_80085164(void);
+void SD_80085480(void);
+int SD_800854F0(void);
+void init_sng_work_8008559C(void);
+void sng_adrs_set_80085658(int idx);
+void se_adrs_set_8008576C(int idx);
+void sng_track_init_800859B8(SOUND_W *ptr);
+
+/* sd_sub1.c */
+extern void (*cntl_tbl_8009F7BC[128])(void);
+extern unsigned char rdm_tbl_8009F9BC[129]; /* char[] */
+extern unsigned char VIBX_TBL_8009FA40[32];
+
+int sound_sub_80085A50(void);
+int tx_read_80085B84(void);
+void note_set_80085CD8(void);
+void adsr_reset_80085D98(void);
+void note_compute_80085DE0(void);
+void vol_compute_8008604C(void);
+void pan_generate_80086198(void);
+void key_cut_off_80086220(void);
+void keych_80086280(void);
+int vib_generate_80086694(int cnt);
+void bendch_80086734(void);
+void note_cntl_8008686C(void);
+unsigned int random_80086B84(void);
+void tempo_ch_80086C08(void);
+void volxset_80086C98(unsigned char depth);
+
+/* sd_sub2.c */
+void rest_set_80086D18(void);
+void tie_set_80086D9C(void);
+void sno_set_80086E38(void);
+void svl_set_80086E78(void);
+void svp_set_80086EB8(void);
+void use_set_80086EF8(void);
+void pan_set_80086F00(void);
+void pan_move_80086F50(void);
+void vib_set_80087018(void);
+void vib_change_80087120(void);
+void rdm_set_8008716C(void);
+void lp1_start_800871B4(void);
+void lp1_end_800871E0(void);
+void lp2_start_800872C0(void);
+void lp2_end_800872EC(void);
+void l3s_set_8008736C(void);
+void l3e_set_80087384(void);
+void tempo_set_800873CC(void);
+void tempo_move_800873E4(void);
+void trans_set_8008750C(void);
+void tre_set_80087524(void);
+void vol_chg_8008756C(void);
+void vol_move_8008758C(void);
+void por_set_80087670(void);
+void sws_set_800876D4(void);
+void detune_set_80087730(void);
+void swp_set_8008774C(void);
+void echo_set1_80087754(void);
+void echo_set2_8008775C(void);
+void eon_set_80087764(void);
+void eof_set_800877CC(void);
+void kakko_start_80087834(void);
+void kakko_end_80087854(void);
+void env_set_800878FC(void);
+void ads_set_80087904(void);
+void srs_set_8008798C(void);
+void rrs_set_800879E4(void);
+void pm_set_80087A48(void);
+void jump_set_80087A50(void);
+void block_end_80087A58(void);
+void no_cmd_80087A80(void);
+
+/* sd_ioset.c */
+extern unsigned int freq_tbl_8009FC08[108];
+
+void spuwr_80087A88(void);
+void sound_off_80087DAC(void);
+void sng_off_80087E2C(void);
+void se_off_80087E94(int i);
+void sng_pause_80087EF4(void);
+void sng_pause_off_80087F24(void);
+void keyon_80087F58(void);
+void keyoff_80087F80(void);
+void tone_set_80087FA8(unsigned char n);
+void pan_set2_800882E4(unsigned char x);
+void vol_set_80088320(unsigned int vol_data);
+void freq_set_800885D4(unsigned int note_tune);
+void drum_set_80088694(unsigned char n);
+
+/* sd_cli.c */
+int sd_task_active_800886C4(void);
+int sd_str_play_800886DC(void);
+int SD_800886F4(void);
+int sub_8008870C(void);
+int sub_8008877C(void);
+int sd_set_cli_800887EC(int sound_code, int sync_mode);
+void sd_set_path_8008880C(const char *str);
+unsigned int sub_80088838(void);
+void sub_80088860(void);
+void start_xa_sd_80088868(void);
+void stop_xa_sd_800888B4(void);
+int SePlay_800888F8(int sound_code);
+int get_str_counter_80088CA0(void);
+void sd_set_80088CB0(int sound_code);
+
+/* in se_tbl.c */
+extern SETBL se_tbl_800A22C4[128];
+
+/* in sd_wk.c */
+extern unsigned long spu_ch_tbl_800A2AC8[24+1];
+extern unsigned char blank_data_800A2B28[512];
+extern unsigned char dummy_data_800A2D28[4096];
+
+/*---------------------------------------------------------------------------*/
+#ifndef __BSSDEFINE__
+
+extern  unsigned long   sd_main_stack_800BE7C8[512];
+extern  unsigned long   sd_int_stack_800BEFC8;
+extern  int             dword_800BEFCC;
+
+extern  int             sd_debug_800BEFD4;
+extern  int             str_pause_wait;
+
+extern  char           *stream_data_ptr_800BEFE4;
+extern  int             str_mono_offset_800BEFE8;
+extern  int             dword_800BEFEC;
+extern  int             str_mute_fg_800BEFF0;
+extern  unsigned int    str_int_ctr_800BEFF4;
+extern  int             dword_800BEFF8;
+
+extern  int             dword_800BEFFC;
+extern  int             dword_800BF000;
+extern  int             se_tracks_800BF004;
+
+extern  int             dword_800BF008;
+extern  unsigned long   blank_data_addr_800BF00C;
+extern  char           *cdload_buf_800BF010; /* unsigned char * */
+extern  int             se_fp_800BF014;
+extern  int             sd_sng_code_buf_800BF018[16];
+extern  char           *str_header_800BF058;
+extern  int             sng_fadein_time_800BF05C;
+extern  int             spu_bgm_start_ptr_l_800BF060;
+extern  int             dword_800BF064;
+extern  SEPLAYTBL       se_playing_800BF068[8];
+extern  int             spu_bgm_start_ptr_r_800BF0C8;
+extern  int             str_fadein_time_800BF0CC;
+extern  unsigned long   mdata1_800BF0D0;
+extern  unsigned long   mdata2_800BF0D4;
+extern  unsigned long   mdata3_800BF0D8;
+extern  unsigned long   mdata4_800BF0DC;
+extern  SEPLAYTBL       se_request_800BF0E0[8];
+extern  unsigned long   spu_load_offset_800BF140;
+extern  int             vox_rev_on_800BF144;
+
+extern  int             dword_800BF154;
+extern  int             sng_status_800BF158;
+extern  unsigned int    str_volume_800BF15C;
+extern  int             str_vox_on_800BF160;
+extern  int             str_play_offset_800BF164;
+extern  int             str_unload_size_800BF168;
+extern  unsigned int    str_status_800BF16C;
+extern  int             str_read_status;
+
+extern  int             se_pan_800BF180[8];
+extern  int             stop_jouchuu_se_800BF1A0;
+extern  int             dword_800BF1A4;
+extern  int             dword_800BF1A8;
+extern  int             str_unplay_size_800BF1AC;
+extern  unsigned long   key_fg_800BF1B0;
+
+extern  int             se_pan_800BF1B8[8];
+extern  int             sng_fp_800BF1D8;
+extern  int             str_mute_status_800BF1DC;
+extern  WAVE_W         *wave_header_800BF1E0; /* unsigned char* */
+
+extern  int             bgm_idx_800BF1E8;
+extern  unsigned long   mtrack_800BF1EC;
+extern  int             se_vol_800BF1F0[8];
+extern  int             dword_800BF210;
+
+extern  SpuVoiceAttr    s_attr_800BF218;
+extern  int             str_fp_800BF258;
+extern  int             sng_fout_fg_800BF25C;
+extern  unsigned long   keyons_800BF260;
+extern  int             str_off_idx_800BF264;
+extern  int             str_mono_fg_800BF268;
+extern  int             str_fout_fg_800BF26C;
+extern  int             dword_800BF270;
+extern  unsigned long   wave_unload_size_800BF274;
+extern  int             str_mute_off_idx;
+extern  unsigned int    dword_800BF27C;
+extern  int             str_trans_offset;
+extern  char           *se_header_800BF284; /* struct SETBL* */
+extern  int             sd_code_read_800BF288;
+extern  unsigned long   se_load_code_800BF28C;
+extern  int             sng_kaihi_fg_800BF290;
+extern  int             wave_data_800BF294;
+extern  int             sng_pause_fg_800BF298;
+extern  unsigned long   keyoffs_800BF29C;
+extern  int             str_read_idx;
+
+extern  SOUND_W         sound_w_800BF2A8[21];
+extern  int             str_play_idx_800C040C;
+extern  int             dword_800C0410;
+extern  int             str_next_idx_800C0414;
+extern  int             str_mute_ctr_800C0418;
+extern  int             sng_fadein_fg_800C041C;
+extern  unsigned char  *sng_data_800C0420;
+
+extern  int             sng_load_code_800C0428;
+
+extern  int             sng_fade_time_800C0430[14];
+extern  char            byte_800C0468[128];
+extern  unsigned long   song_end_800C04E8;
+extern  int             str_fadein_fg_800C04EC;
+extern  int             str_load_code_800C04F0;
+extern  int             str_fade_time_800C04F4;
+extern  unsigned int    sng_play_code_800C04F8;
+
+extern  int             dword_800C0500;
+extern  int             str_freq_800C0504;
+extern  char           *wave_load_ptr_800C0508; /* unsigned char* */
+extern  int             sound_mono_fg_800C050C;
+extern  int             sng_syukan_fg_800C0510;
+extern  char           *str_trans_buf_800C0514;
+extern  int             sng_fout_term_800C0518;
+extern  int             str_wave_size_800C051C;
+// extern  unsigned char  *se_exp_table_800C0520;
+// extern  SETBL          *se_exp_table_800C0520;
+extern  unsigned long   keyd_800C0524;
+extern  unsigned long   wave_load_code_800C0528;
+extern  unsigned long   spu_wave_start_ptr_800C052C;
+extern  WAVE_W         *voice_tbl_800C0530;
+
+extern  int             sng_fade_value_800C0538[13];
+extern  unsigned char   byte_800C056C;
+
+extern  unsigned char  *mptr_800C0570;
+extern  int             se_rev_on_800C0574;
+extern  unsigned long   wave_save_code_800C0578;
+extern  SOUND_W        *sptr_800C057C;
+extern  int             dword_800C0580;
+extern  unsigned int    str_fade_value_800C0584;
+extern  char            spu_malloc_rec_800C0588[200];
+extern  int             dword_800C0650;
+extern  int             dword_800C0654;
+extern  SPU_TRACK_REG   spu_tr_wk_800C0658[23];
+
+extern  int             sng_fade_in_2_800C0BC0;
+
+extern  int             sng_master_vol_800C0BC8[13];
+extern  volatile int    sd_task_status_800C0BFC;
+
+
+#endif // __BSSDEFINE__
+#endif // _SD_EXT_H_

--- a/src/SD/sd_file.c
+++ b/src/SD/sd_file.c
@@ -1,42 +1,10 @@
-#include "SD/sound.h"
 #include "SD/sd_incl.h"
+#include "SD/sd_ext.h"
+
 #include "libfs/libfs.h"
 #include "psyq.h"
 
-extern char            *cdload_buf_800BF010;
-extern int              se_fp_800BF014;
-extern int              spu_load_offset_800BF140;
-extern int              sng_status_800BF158;
-extern unsigned int     str_volume_800BF15C;
-extern unsigned int     str_status_800BF16C;
-extern int              str_mute_status_800BF1DC;
-extern WAVE_W          *voice_tbl_800BF1E0;
-extern int              str_fout_fg_800BF26C;
-extern int              wave_unload_size_800BF274;
-extern unsigned int     dword_800BF27C;
-extern int              se_load_code_800BF28C;
-extern int              wave_data_800BF294;
-extern int              str_mute_ctr_800C0418;
-extern unsigned char   *sng_data_800C0420;
-extern int              str_fadein_fg_800C04EC;
-extern int              str_load_code_800C04F0;
-extern int              str_fade_time_800C04F4;
-extern unsigned int     sng_play_code_800C04F8;
-extern int              dword_800C0500;
-extern char            *wave_load_ptr_800C0508;
-extern int              sound_mono_fg_800C050C;
-extern unsigned char   *se_exp_table_800C0520;
-extern int              wave_load_code_800C0528;
-extern int              spu_wave_start_ptr_800C052C;
-extern unsigned char    byte_800C056C;
-extern int              wave_save_code_800C0578;
-extern int              dword_800C0650;
-extern unsigned int     str_fade_value_800C0584;
-
-/* in sd_main.c */
-void nullsub_7_80081A10(int *arg0, int arg1, int arg2);
-void keyOff_80081FC4(unsigned int ch);
-void sng_off_80087E2C(void); /* in sd_ioset.c */
+extern unsigned char *se_exp_table_800C0520;
 
 int SD_LoadSeFile_8008341C(void)
 {
@@ -104,7 +72,7 @@ int SD_LoadWaveFile_800834FC(void)
     printf("SUP OFFSET=%x:SIZE=%x\n", offset, size);
 
     wave_load_ptr_800C0508 = cdload_buf_800BF010 + 16;
-    dst = (char *)voice_tbl_800BF1E0 + offset;
+    dst = (char *)wave_header_800BF1E0 + offset;
     memcpy(dst, wave_load_ptr_800C0508, size);
 
     printf("    SRC=%x:DST=%x\n", (unsigned int)wave_load_ptr_800C0508, (unsigned int)dst);
@@ -293,10 +261,11 @@ int StrFadeInt_800839C8(void)
     return 0;
 }
 
-char num2char_80083E68(unsigned int num);
-
 void code2name_80083BB4(unsigned int code, char *name)
 {
+    /* forward declaration */
+    extern char num2char_80083E68(unsigned int num);
+
     if ((code + 0xff000000) <= 0xffff)
     {
         name[ 0] = 'S';
@@ -436,7 +405,7 @@ int SD_80083F54(char *end)
     offset |= cdload_buf_800BF010[2] << 8;
     offset |= cdload_buf_800BF010[3];
 
-    dst = (char *)voice_tbl_800BF1E0 + offset;
+    dst = (char *)wave_header_800BF1E0 + offset;
 
     size = cdload_buf_800BF010[4] << 24;
     size |= cdload_buf_800BF010[5] << 16;

--- a/src/SD/sd_ioset.c
+++ b/src/SD/sd_ioset.c
@@ -1,35 +1,17 @@
-#include "SD/sound.h"
 #include "SD/sd_incl.h"
+#include "SD/sd_ext.h"
 #include "psyq.h"
 
-extern SOUND_W      *sptr_800C057C;
-extern SPU_TRACK_REG spu_tr_wk_800C0658[23];
-extern unsigned int  mtrack_800BF1EC;
-extern int           keyons_800BF260;
-extern int           keyd_800C0524;
-extern int           keyoffs_800BF29C;
-extern int           song_end_800C04E8;
-extern unsigned int  spu_ch_tbl_800A2AC8[]; /* in sd_wk.c */
-extern SEPLAYTBL     se_playing_800BF068[8];
-extern WAVE_W       *voice_tbl_800C0530;
-extern int           se_pan_800BF180[8];
-extern int           se_pan_800BF1B8[8];
-extern int           sound_mono_fg_800C050C;
-extern int           sng_master_vol_800C0BC8[13];
-extern int           dword_800BF064;
-extern int           dword_800BF210;
-extern int           spu_wave_start_ptr_800C052C;
-extern unsigned char byte_800C056C;
+#define STATIC
+// #define STATIC static
 
-/*static*/
-int pant_8009FA60[41] = {
+STATIC unsigned long pant_8009FA60[41] = {
     0,   2,   4,   7,   10,  13,  16,  20,  24,  28,  32,  36,  40,  45,
     50,  55,  60,  65,  70,  75,  80,  84,  88,  92,  96,  100, 104, 107,
     110, 112, 114, 116, 118, 120, 122, 123, 124, 125, 126, 127, 127
 };
 
-/*static*/
-int se_pant_8009FB04[65] = {
+STATIC unsigned long se_pant_8009FB04[65] = {
     0,   2,   4,   6,   8,   10,  14,  18,  22,  28,  34,  40,  46,
     52,  58,  64,  70,  76,  82,  88,  94,  100, 106, 112, 118, 124,
     130, 136, 142, 148, 154, 160, 166, 172, 178, 183, 188, 193, 198,
@@ -37,7 +19,7 @@ int se_pant_8009FB04[65] = {
     244, 246, 248, 249, 250, 251, 252, 253, 254, 254, 255, 255, 255
 };
 
-int freq_tbl_8009FC08[108] = {
+unsigned int freq_tbl_8009FC08[108] = {
     0x010B, 0x011B, 0x012C, 0x013E, 0x0151, 0x0165, 0x017A, 0x0191,
     0x01A9, 0x01C2, 0x01DD, 0x01F9, 0x0217, 0x0237, 0x0259, 0x027D,
     0x02A3, 0x02CB, 0x02F5, 0x0322, 0x0352, 0x0385, 0x03BA, 0x03F3,
@@ -53,8 +35,6 @@ int freq_tbl_8009FC08[108] = {
     0x0085, 0x008D, 0x0096, 0x009F, 0x00A8, 0x00B2, 0x00BD, 0x00C8,
     0x00D4, 0x00E1, 0x00EE, 0x00FC
 };
-
-void pan_set2_800882E4(unsigned char x);
 
 void spuwr_80087A88(void)
 {

--- a/src/SD/sd_main.c
+++ b/src/SD/sd_main.c
@@ -1,60 +1,12 @@
-#include "SD/sound.h"
 #include "SD/sd_incl.h"
+#include "SD/sd_ext.h"
+
 #include "libfs/libfs.h"
 #include "mts/mts_new.h"
 #include "mts/taskid.h"
 #include "psyq.h"
 
-void sd_init_80081C7C(void);
-void IntSdMain_80084494(void);
-void WaveSpuTrans_80083944(void);
-void StrSpuTrans_800833FC(void);
-int  StrFadeInt_800839C8(void);
-void SdInt_80081BDC(void);
-void SD_nullsub_20_800827A4(void);
-int  SD_LoadSeFile_8008341C(void);
-int  SD_800854F0(void);
-void KeyOffStr_80081FE8(void);
-int  StartStream_80082448(void);
-void keyOn_80082170(unsigned int ch);
-void sng_off_80087E2C(void);
-void UserSpuIRQProc_80082640(void);
-int  sd_mem_alloc_80082194(void);
-void StrSpuTransClose_80083394(void);
-
-extern int            sng_status_800BF158;
-extern int            se_load_code_800BF28C;
-extern unsigned char *sng_data_800C0420;
-extern char          *cdload_buf_800BF010;
-extern int            sd_task_status_800C0BFC;
-extern int            sd_int_stack_800BEFC8;
-extern int            dword_800BEFCC;
-extern int            dword_800BF1A4;
-extern int            str_fout_fg_800BF26C;
-extern unsigned int   str_status_800BF16C;
-extern int            sd_debug_800BEFD4;
-extern unsigned int   sd_main_stack_800BE7C8[512];
-extern int            str_load_code_800C04F0;
-extern int            str_fp_800BF258;
-extern int            dword_800C0580;
 extern unsigned char *se_exp_table_800C0520;
-extern int            spu_bgm_start_ptr_l_800BF060;
-extern int            spu_bgm_start_ptr_r_800BF0C8;
-extern SEPLAYTBL      se_playing_800BF068[8];
-extern int            dword_800BF210;
-extern int            dword_800BF064;
-extern int            dword_800BF1A8;
-extern unsigned char  blank_data_800A2B28[512]; /* in sd_wk.c */
-extern unsigned int   dword_800BF27C;
-extern unsigned char  byte_800C0588[200];
-extern int            blank_data_addr_800BF00C;
-extern int            spu_wave_start_ptr_800C052C;
-extern SpuVoiceAttr   s_attr_800BF218;
-extern WAVE_W        *voice_tbl_800BF1E0;
-extern char          *se_header_800BF284;
-extern char          *str_header_800BF058;
-extern char          *str_trans_buf_800C0514;
-extern WAVE_W        *voice_tbl_800C0530;
 
 void sound_main_80081910(int argc, const char *argv[])
 {
@@ -188,7 +140,7 @@ void sd_init_80081C7C(void)
     SpuReverbAttr r_attr;
 
     SpuInit();
-    SpuInitMalloc(24, byte_800C0588);
+    SpuInitMalloc(24, spu_malloc_rec_800C0588);
     c_attr.mask = 3;
     c_attr.mvol.left = 0;
     c_attr.mvol.right = 0;
@@ -355,13 +307,13 @@ int sd_mem_alloc_80082194(void)
     sng_data_800C0420 = (unsigned char *)0x801E0000;
     printf("sng_data %X\n", (unsigned int)sng_data_800C0420);
 
-    voice_tbl_800BF1E0 = (WAVE_W *)(sng_data_800C0420 + 0x4000);
+    wave_header_800BF1E0 = (WAVE_W *)(sng_data_800C0420 + 0x4000);
     printf("wave_header %X\n", (unsigned int)sng_data_800C0420 + 0x4000);
 
-    voice_tbl_800C0530 = voice_tbl_800BF1E0;
-    printf("voice_tbl %X\n", (unsigned int)voice_tbl_800BF1E0);
+    voice_tbl_800C0530 = wave_header_800BF1E0;
+    printf("voice_tbl %X\n", (unsigned int)wave_header_800BF1E0);
 
-    se_exp_table_800C0520 = (unsigned char *)&voice_tbl_800BF1E0[256];
+    se_exp_table_800C0520 = (unsigned char *)&wave_header_800BF1E0[256];
     printf("se_header %X\n", (unsigned int)se_exp_table_800C0520);
 
     se_header_800BF284 = se_exp_table_800C0520 + 0x800;

--- a/src/SD/sd_str.c
+++ b/src/SD/sd_str.c
@@ -1,73 +1,32 @@
-#include "SD/sound.h"
 #include "SD/sd_incl.h"
+#include "SD/sd_ext.h"
+
 #include "libfs/libfs.h"
 #include "mts/mts_new.h"
 #include "mts/taskid.h"
 #include "psyq.h"
 
-extern unsigned char    dummy_data_800A2D28[4096]; /* in sd_wk.c */
-extern char            *stream_data_ptr_800BEFE4;
-extern int              str_mono_offset_800BEFE8;
-extern int              dword_800BEFEC;
-extern int              str_mute_fg_800BEFF0;
-extern int              str_int_ctr_800BEFF4;
-extern char            *str_header_800BF058;
-extern int              spu_bgm_start_ptr_l_800BF060;
-extern int              spu_bgm_start_ptr_r_800BF0C8;
-extern int              blank_data_addr_800BF00C;
-extern int              str_fadein_time_800BF0CC;
-extern int              vox_rev_on_800BF144;
-extern unsigned int     str_volume_800BF15C;
-extern int              str_vox_on_800BF160;
-extern int              str_play_offset_800BF164;
-extern int              str_unload_size_800BF168;
-extern unsigned int     str_status_800BF16C;
-extern int              dword_800BF1A4;
-extern int              dword_800BF1A8;
-extern int              str_unplay_size_800BF1AC;
-extern int              str_mute_status_800BF1DC;
-extern int              str_off_idx_800BF264;
-extern int              str_mono_fg_800BF268;
-extern int              str_fout_fg_800BF26C;
-extern int              dword_800BF270;
-extern int              str_play_idx_800C040C;
-extern int              str_next_idx_800C0414;
-extern int              str_mute_ctr_800C0418;
-extern int              str_fadein_fg_800C04EC;
-extern int              str_load_code_800C04F0;
-extern int              str_fade_time_800C04F4;
-extern int              str_freq_800C0504;
-extern int              str_wave_size_800C051C;
-extern int              se_rev_on_800C0574;
-extern int              dword_800C0580;
-extern unsigned int     str_fade_value_800C0584;
-
-
-/* in sd_main.c */
-void keyOff_80081FC4(unsigned int ch);
-void keyOn_80082170(unsigned int ch);
-
 int dword_8009F7B4 = -1;
 char *dword_8009F7B8 = 0;
 
-void StrFadeIn_800822C8(unsigned int a1)
+void StrFadeIn_800822C8(unsigned int arg0)
 {
-    str_fadein_time_800BF0CC = str_volume_800BF15C / a1;
-    if (!(str_volume_800BF15C / a1))
+    str_fadein_time_800BF0CC = str_volume_800BF15C / arg0;
+    if (!(str_volume_800BF15C / arg0))
     {
         str_fadein_time_800BF0CC = 1;
     }
     str_fade_time_800C04F4 = 0;
 }
 
-int StrFadeOut_80082310(unsigned int a1)
+int StrFadeOut_80082310(unsigned int arg0)
 {
     if (str_status_800BF16C)
     {
         if (str_fade_value_800C0584 != str_volume_800BF15C)
         {
-            str_fade_time_800C04F4 = str_volume_800BF15C / a1;
-            if (!(str_volume_800BF15C / a1))
+            str_fade_time_800C04F4 = str_volume_800BF15C / arg0;
+            if (!(str_volume_800BF15C / arg0))
             {
                 str_fade_time_800C04F4 = 1;
             }

--- a/src/SD/sd_sub1.c
+++ b/src/SD/sd_sub1.c
@@ -1,74 +1,10 @@
-#include "SD/sound.h"
 #include "SD/sd_incl.h"
+#include "SD/sd_ext.h"
 
-unsigned char         rdm_tbl_8009F9BC[129];
-extern SOUND_W       *sptr_800C057C;
-extern SPU_TRACK_REG  spu_tr_wk_800C0658[23];
-extern unsigned int   mtrack_800BF1EC;
-extern unsigned int   mdata1_800BF0D0;
-extern int            mdata2_800BF0D4;
-extern int            mdata3_800BF0D8;
-extern int            mdata4_800BF0DC;
-extern int            sng_fade_in_2_800C0BC0;
-extern int            key_fg_800BF1B0;
-extern unsigned char *mptr_800C0570;
-
-extern void (*cntl_tbl_8009F7BC[128])(void);
-extern unsigned char VIBX_TBL_8009FA40[32];
-
-unsigned int random_80086B84(void);
-void note_set_80085CD8(void);
-void tempo_ch_80086C08(void);
-void keych_80086280(void);
-int  tx_read_80085B84(void);
-void bendch_80086734(void);
-void vol_compute_8008604C(void);
-void note_cntl_8008686C(void);
-void keyon_80087F58(void);
-
-void note_compute_80085DE0(void);
+/* local inlines */
 inline int  vib_compute_800865CC(void);
 inline void por_compute_80086504(void);
 inline void swpadset_80085F98(int xfreq);
-
-/* in sd_sub2.c */
-void no_cmd_80087A80(void);
-void tempo_set_800873CC(void);
-void tempo_move_800873E4(void);
-void sno_set_80086E38(void);
-void svl_set_80086E78(void);
-void svp_set_80086EB8(void);
-void vol_chg_8008756C(void);
-void vol_move_8008758C(void);
-void ads_set_80087904(void);
-void srs_set_8008798C(void);
-void rrs_set_800879E4(void);
-void pan_set_80086F00(void);
-void pan_move_80086F50(void);
-void trans_set_8008750C(void);
-void detune_set_80087730(void);
-void vib_set_80087018(void);
-void vib_change_80087120(void);
-void rdm_set_8008716C(void);
-void swp_set_8008774C(void);
-void sws_set_800876D4(void);
-void por_set_80087670(void);
-void lp1_start_800871B4(void);
-void lp1_end_800871E0(void);
-void lp2_start_800872C0(void);
-void lp2_end_800872EC(void);
-void l3s_set_8008736C(void);
-void l3e_set_80087384(void);
-void kakko_start_80087834(void);
-void kakko_end_80087854(void);
-void use_set_80086EF8(void);
-void rest_set_80086D18(void);
-void tie_set_80086D9C(void);
-void echo_set1_80087754(void);
-void echo_set2_8008775C(void);
-void eon_set_80087764(void);
-void eof_set_800877CC(void);
-void block_end_80087A58(void);
 
 void (*cntl_tbl_8009F7BC[128])(void) = {
     /* 0x00 */ no_cmd_80087A80,

--- a/src/SD/sd_sub2.c
+++ b/src/SD/sd_sub2.c
@@ -1,23 +1,5 @@
-#include "SD/sound.h"
 #include "SD/sd_incl.h"
-
-extern int keyoffs_800BF29C;
-extern int keyd_800C0524;
-extern SOUND_W* sptr_800C057C;
-extern unsigned int mtrack_800BF1EC;
-extern SPU_TRACK_REG spu_tr_wk_800C0658[];
-extern int mdata2_800BF0D4;
-extern int mdata3_800BF0D8;
-extern int mdata4_800BF0DC;
-extern unsigned char* mptr_800C0570;
-extern int spu_ch_tbl_800A2AC8[]; /* in sd_wk.c */
-extern int dword_800BF210;
-extern SEPLAYTBL se_playing_800BF068[8];
-extern int dword_800BF064;
-extern int stop_jouchuu_se_800BF1A0;
-
-void tone_set_80087FA8(unsigned char n);
-void block_end_80087A58(void);
+#include "SD/sd_ext.h"
 
 void rest_set_80086D18(void)
 {

--- a/src/SD/sd_wk.c
+++ b/src/SD/sd_wk.c
@@ -1,6 +1,6 @@
 #include "SD/sd_incl.h"
 
-int spu_ch_tbl_800A2AC8[] = {
+unsigned long spu_ch_tbl_800A2AC8[24+1] = {
     0x00000001,
     0x00000001, 0x00000002, 0x00000004, 0x00000008,
     0x00000010, 0x00000020, 0x00000040, 0x00000080,

--- a/src/SD/se_data/blob.h
+++ b/src/SD/se_data/blob.h
@@ -74,7 +74,7 @@ unsigned int dclose0100[] = { // UNUSED, guessed from "dcl..."
     0xD77F000F, 0x1008287F, 0xE4000804, 0x0406287F,
     0xD2262854, 0x28102868, 0xE4000604, 0xFFFE0000
 };
-unsigned int seunk06000[] = {
+unsigned int panel0100[] = { // guessed name
     0xD0FF0000, 0xD57F0000, 0xD204507F, 0xD77F000F,
     0xD8000000, 0xD9180000, 0x47030168, 0x23030168,
     0xE7060140, 0x3B015A68, 0x3A015A68, 0xE803009D,
@@ -129,7 +129,7 @@ unsigned int ninja0100[] = {
     0xD8480C0C, 0xD911637F, 0x46302840, 0xE4000645,
     0xFFFE0000
 };
-unsigned int seunk07900[] = {
+unsigned int lockon100[] = { // guessed name
     0xD0FF0000, 0xD5FF0000, 0xF607507F, 0xD207507F,
     0xD77F000F, 0xD8000000, 0xD9180000, 0xDD000018,
     0xDF0C3218, 0x43062814, 0xFFFE0000
@@ -219,7 +219,7 @@ unsigned int isel0100[] = { // guessed name
     0xD77F0905, 0xD8000000, 0xD9110000, 0x3912017F,
     0xFFFE0000
 };
-unsigned int nikita0100[] = { // guessed
+unsigned int nikita0100[] = { // guessed name
     0xD0780000, 0xF7FF0000, 0xD5FF0000, 0xD23F0000,
     0xDF00000F, 0xD77F000F, 0xD8000000, 0xD91F0000,
     0x1D2C6350, 0xE4061811, 0xFFFE0000
@@ -1017,7 +1017,7 @@ unsigned int backcls200[] = {
     0xD2320000, 0xD760000F, 0xD8400000, 0xD9100000,
     0x1060037F, 0xFFFE0000
 };
-unsigned int seunk10100[] = {
+unsigned int shot_s0200[] = { // guessed name
 #ifdef VR_EXE
     0xD0FC0100, 0xD5960000, 0xF6800000, 0xD2270100,
     0xD77F000F, 0xD8006366, 0xD9196366, 0x2201014E,

--- a/src/SD/se_tbl.c
+++ b/src/SD/se_tbl.c
@@ -70,7 +70,7 @@ SETBL se_tbl_800A22C4[128] = {
     { 0x20, 0x01, 0x01, 0x00, { ADDR(k_swing100), SE_DUMMY, SE_DUMMY }}, /* 57 */
     { 0x90, 0x02, 0x00, 0x00, { ADDR(chaf000300), ADDR(chaf000301), SE_DUMMY }}, /* 58 */
     { 0x60, 0x01, 0x01, 0x00, { ADDR(hibana0100), SE_DUMMY, SE_DUMMY }}, /* 59 */
-    { 0x40, 0x01, 0x01, 0x00, { ADDR(seunk06000), SE_DUMMY, SE_DUMMY }}, /* 60 */
+    { 0x40, 0x01, 0x01, 0x00, { ADDR(panel0100), SE_DUMMY, SE_DUMMY }}, /* 60 */
     { 0x30, 0x01, 0x01, 0x00, { ADDR(seunk06100), SE_DUMMY, SE_DUMMY }}, /* 61 */
     { 0x40, 0x01, 0x01, 0x00, { ADDR(rebglass00), SE_DUMMY, SE_DUMMY }}, /* 62 */
     { 0x60, 0x01, 0x01, 0x00, { ADDR(glass1100),  SE_DUMMY, SE_DUMMY }}, /* 63 */
@@ -89,7 +89,7 @@ SETBL se_tbl_800A22C4[128] = {
     { 0x40, 0x01, 0x01, 0x00, { ADDR(nikita0100), SE_DUMMY, SE_DUMMY }}, /* 76 */
     { 0x40, 0x01, 0x01, 0x00, { ADDR(nikita0200), SE_DUMMY, SE_DUMMY }}, /* 77 */
     { 0x30, 0x01, 0x01, 0x00, { ADDR(ninja0100),  SE_DUMMY, SE_DUMMY }}, /* 78 */
-    { 0x30, 0x01, 0x00, 0x00, { ADDR(seunk07900), SE_DUMMY, SE_DUMMY }}, /* 79 */
+    { 0x30, 0x01, 0x00, 0x00, { ADDR(lockon100),  SE_DUMMY, SE_DUMMY }}, /* 79 */
     { 0x30, 0x01, 0x01, 0x00, { ADDR(ninja0200),  SE_DUMMY, SE_DUMMY }}, /* 80 */
     { 0x60, 0x01, 0x01, 0x00, { ADDR(hiza0100),   SE_DUMMY, SE_DUMMY }}, /* 81 */
     { 0x40, 0x01, 0x01, 0x00, { ADDR(shot_s0100), SE_DUMMY, SE_DUMMY }}, /* 82 */
@@ -111,7 +111,7 @@ SETBL se_tbl_800A22C4[128] = {
     { 0x20, 0x01, 0x01, 0x00, { ADDR(eleopn0300), SE_DUMMY, SE_DUMMY }}, /* 98 */
     { 0x10, 0x01, 0x01, 0x00, { ADDR(sight0800),  SE_DUMMY, SE_DUMMY }}, /* 99 */
     { 0xFF, 0x03, 0x00, 0x00, { ADDR(inelev0200), ADDR(inelev0201), ADDR(inelev0202) }}, /* 100 */
-    { 0x40, 0x01, 0x01, 0x00, { ADDR(seunk10100), SE_DUMMY, SE_DUMMY }}, /* 101 */
+    { 0x40, 0x01, 0x01, 0x00, { ADDR(shot_s0200), SE_DUMMY, SE_DUMMY }}, /* 101 */
     { 0xF0, 0x02, 0x00, 0x00, { ADDR(start00100), ADDR(start00101), SE_DUMMY }}, /* 102 */
     { 0x20, 0x01, 0x00, 0x00, { ADDR(r_tune0100), SE_DUMMY, SE_DUMMY }}, /* 103 */
     { 0x80, 0x01, 0x00, 0x00, { ADDR(r_cancel00), SE_DUMMY, SE_DUMMY }}, /* 104 */

--- a/src/SD/sound.h
+++ b/src/SD/sound.h
@@ -1,33 +1,24 @@
 #ifndef _SOUND_H_
 #define _SOUND_H_
 
-void               keyoff_80087F80(void);
-int                SD_8008395C(int a1, int a2);
-int                SD_80083954(int a1, unsigned char *a2, int a3);
-void               init_sng_work_8008559C(void);
-int                SD_SongLoadData_8008394C(int a1, int a2);
-void               freq_set_800885D4(unsigned int note_tune);
-int                get_str_counter_80088CA0(void);
-int                sd_str_play_800886DC(void);
-int                sd_set_cli_800887EC(int sound_code, int sync_mode);
-unsigned char     *SD_SngDataLoadInit_80083E8C(unsigned short);
-char              *LoadInit_80083F08(unsigned short);
-void               SD_80083ED4(void);
-unsigned char     *SD_80083EE8(unsigned short);
-void               SD_Unload_800843BC(void);
-char              *SD_WavLoadBuf_800841D4(char *arg0);
-void               StrFadeWkSet_80083964(void);
-void               volxset_80086C98(unsigned char depth);
-void               pan_generate_80086198(void);
-void               drum_set_80088694(unsigned char n);
-void               vol_set_80088320(unsigned int vol_data);
-void               StrFadeIn_800822C8(unsigned int a1);
-int                StrFadeOut_80082310(unsigned int a1);
-int                StrFadeOutStop_80082380(unsigned int fadeSpeed);
-void               SdMain_80081A18(void);
-int                sd_task_active_800886C4(void);
-void               start_xa_sd_80088868(void);
-void               stop_xa_sd_800888B4(void);
-int                SD_800886F4(void);
+/* sd_main.c */
+void SdMain_80081A18(void);
+
+/* sd_cli.c */
+int sd_task_active_800886C4(void);
+int sd_str_play_800886DC(void);
+int SD_800886F4(void);
+int sd_set_cli_800887EC(int sound_code, int sync_mode);
+void start_xa_sd_80088868(void);
+void stop_xa_sd_800888B4(void);
+int get_str_counter_80088CA0(void);
+
+/* sd_file.c */
+unsigned char *SD_SngDataLoadInit_80083E8C(unsigned short);
+void SD_80083ED4(void);
+unsigned char *SD_80083EE8(unsigned short);
+char *LoadInit_80083F08(unsigned short);
+char *SD_WavLoadBuf_800841D4(char *arg0);
+void SD_Unload_800843BC(void);
 
 #endif // _SOUND_H_

--- a/src/Thing/sgtrect3.c
+++ b/src/Thing/sgtrect3.c
@@ -72,7 +72,7 @@ extern int     amissile_alive_8009F490;
 extern SVECTOR GM_PlayerPosition_800ABA10;
 extern SVECTOR svector_8009F478;
 
-void sgtrect3_act_helper_8007020C(Actor_sgtrect3 *sgtrect3, DVECTOR *outScreenCoordsArray, TARGET **outTargetsArray,
+void sgtrect3_act_helper_8007020C(SgtRect3Work *work, DVECTOR *outScreenCoordsArray, TARGET **outTargetsArray,
                                   ushort *outResultsArray)
 {
     int         downCount;
@@ -157,62 +157,62 @@ void sgtrect3_act_helper_8007020C(Actor_sgtrect3 *sgtrect3, DVECTOR *outScreenCo
         {
             if (!lastTarget)
             {
-                if (sgtrect3->field_30_target)
+                if (work->field_30_target)
                 {
-                    sgtrect3->field_34_count++;
-                    sgtrect3->field_38++;
-                    if (sgtrect3->field_38 >= 24)
+                    work->field_34_count++;
+                    work->field_38++;
+                    if (work->field_38 >= 24)
                     {
-                        sgtrect3->field_34_count = 0;
-                        sgtrect3->field_38 = 0;
-                        sgtrect3->field_30_target = NULL;
+                        work->field_34_count = 0;
+                        work->field_38 = 0;
+                        work->field_30_target = NULL;
                     }
                     #ifdef VR_EXE
-                        if (sgtrect3->field_30_target->class & TARGET_NO_LOCKON)
+                        if (work->field_30_target->class & TARGET_NO_LOCKON)
                         {
-                            sgtrect3->field_34_count = 0;
-                            sgtrect3->field_38 = 0;
-                            sgtrect3->field_30_target = NULL;
+                            work->field_34_count = 0;
+                            work->field_38 = 0;
+                            work->field_30_target = NULL;
                         }
                     #endif
                 }
             }
             else
             {
-                sgtrect3->field_38 = 0;
-                if (sgtrect3->field_30_target == lastTarget)
+                work->field_38 = 0;
+                if (work->field_30_target == lastTarget)
                 {
-                    sgtrect3->field_34_count++;
+                    work->field_34_count++;
                 }
                 else
                 {
-                    sgtrect3->field_34_count = 0;
+                    work->field_34_count = 0;
                 }
-                sgtrect3->field_30_target = lastTarget;
+                work->field_30_target = lastTarget;
             }
         }
-        else if (sgtrect3->field_30_target)
+        else if (work->field_30_target)
         {
-            if (!sgtrect3_act_helper_800701A8(sgtrect3->field_30_target))
+            if (!sgtrect3_act_helper_800701A8(work->field_30_target))
             {
-                sgtrect3->field_34_count = 0;
-                sgtrect3->field_38 = 0;
-                sgtrect3->field_30_target = NULL;
+                work->field_34_count = 0;
+                work->field_38 = 0;
+                work->field_30_target = NULL;
             }
             else
             {
-                sgtrect3->field_34_count++;
-                sgtrect3->field_38 = 24;
+                work->field_34_count++;
+                work->field_38 = 24;
             }
         }
 
-        sgtrect3->field_21AC_target_count = targetCount;
+        work->field_21AC_target_count = targetCount;
     }
 }
 
 extern int GV_Clock_800AB920;
 
-void sgtrect3_act_helper_80070568(Actor_sgtrect3 *sgtrect3, void *ot, LINE_F3 *lineF3Arr)
+void sgtrect3_act_helper_80070568(SgtRect3Work *work, void *ot, LINE_F3 *lineF3Arr)
 {
     int count;
     int index;
@@ -230,13 +230,13 @@ void sgtrect3_act_helper_80070568(Actor_sgtrect3 *sgtrect3, void *ot, LINE_F3 *l
 
     int multiplicand;
 
-    count = sgtrect3->field_34_count;
+    count = work->field_34_count;
     if (0xc < count)
     {
         count = 0xc;
     }
 
-    firstLineF4 = sgtrect3->field_1C3C_lines[GV_Clock_800AB920].field_0;
+    firstLineF4 = work->field_1C3C_lines[GV_Clock_800AB920].field_0;
     secondLineF4 = firstLineF4 + 1;
     for (index = 0; index < count; index++)
     {
@@ -258,16 +258,16 @@ void sgtrect3_act_helper_80070568(Actor_sgtrect3 *sgtrect3, void *ot, LINE_F3 *l
 
         if (index != 11)
         {
-            multiplicand = 16 - (sgtrect3->field_34_count - index);
+            multiplicand = 16 - (work->field_34_count - index);
 
             if (multiplicand < 0)
             {
                 multiplicand = 0;
             }
 
-            firstLineF4->r0 = (unsigned int)(sgtrect3->field_2C_rgb.rgbChars[0] * multiplicand) >> 4;
-            firstLineF4->g0 = (unsigned int)(sgtrect3->field_2C_rgb.rgbChars[1] * multiplicand) >> 4;
-            firstLineF4->b0 = (unsigned int)(sgtrect3->field_2C_rgb.rgbChars[2] * multiplicand) >> 4;
+            firstLineF4->r0 = (unsigned int)(work->field_2C_rgb.rgbChars[0] * multiplicand) >> 4;
+            firstLineF4->g0 = (unsigned int)(work->field_2C_rgb.rgbChars[1] * multiplicand) >> 4;
+            firstLineF4->b0 = (unsigned int)(work->field_2C_rgb.rgbChars[2] * multiplicand) >> 4;
             secondLineF4->r0 = firstLineF4->r0;
             secondLineF4->g0 = firstLineF4->g0;
             secondLineF4->b0 = firstLineF4->b0;
@@ -279,7 +279,7 @@ void sgtrect3_act_helper_80070568(Actor_sgtrect3 *sgtrect3, void *ot, LINE_F3 *l
         secondLineF4 += 2;
     }
 
-    sgtrect3_act_helper_helper_80070040(ot, &sgtrect3->field_23B8_prim[GV_Clock_800AB920]);
+    sgtrect3_act_helper_helper_80070040(ot, &work->field_23B8_prim[GV_Clock_800AB920]);
 }
 
 void sgtrect3_act_helper_80070820(void *ot, LINE_F3 *lineF3Arr, LINE_F2 *lineF2Arr, DVECTOR *screenCoords,
@@ -351,7 +351,7 @@ void sgtrect3_act_helper_80070820(void *ot, LINE_F3 *lineF3Arr, LINE_F2 *lineF2A
     sgtrect3_act_helper_helper_80070040(ot, secondLineF2);
 }
 
-void sgtrect3_act_helper_80070AB0(Actor_sgtrect3 *sgtrect3, DVECTOR *screenCoordsArray, TARGET **inTargets,
+void sgtrect3_act_helper_80070AB0(SgtRect3Work *work, DVECTOR *screenCoordsArray, TARGET **inTargets,
                                   unsigned short *offsets)
 {
     unsigned int  rgb;
@@ -369,14 +369,14 @@ void sgtrect3_act_helper_80070AB0(Actor_sgtrect3 *sgtrect3, DVECTOR *screenCoord
     LINE_F2  *lineF2Arr;
     DR_TPAGE *tPageArr;
 
-    rgbFields = &sgtrect3->field_28_rgb.rgbWord;
-    targetCount = sgtrect3->field_21AC_target_count;
-    field_21B4 = sgtrect3->field_21B4;
-    lineF3Arr = sgtrect3->field_3C[GV_Clock_800AB920].field_0;
-    lineF2Arr = sgtrect3->field_C3C[GV_Clock_800AB920].field_0;
-    tPageArr = sgtrect3->field_21B8[GV_Clock_800AB920].field_0;
+    rgbFields = &work->field_28_rgb.rgbWord;
+    targetCount = work->field_21AC_target_count;
+    field_21B4 = work->field_21B4;
+    lineF3Arr = work->field_3C[GV_Clock_800AB920].field_0;
+    lineF2Arr = work->field_C3C[GV_Clock_800AB920].field_0;
+    tPageArr = work->field_21B8[GV_Clock_800AB920].field_0;
     ot = DG_ChanlOTag(1);
-    field_30_target = sgtrect3->field_30_target;
+    field_30_target = work->field_30_target;
 
     for (targetCount--; targetCount >= 0; screenCoordsArray++, inTargets++, offsets++, targetCount--)
     {
@@ -405,7 +405,7 @@ void sgtrect3_act_helper_80070AB0(Actor_sgtrect3 *sgtrect3, DVECTOR *screenCoord
 
         if ((currentTarget == field_30_target) && (field_21B4 != 0))
         {
-            sgtrect3_act_helper_80070568(sgtrect3, ot, lineF3Arr);
+            sgtrect3_act_helper_80070568(work, ot, lineF3Arr);
         }
 
         lineF3Arr += 2;
@@ -416,7 +416,7 @@ void sgtrect3_act_helper_80070AB0(Actor_sgtrect3 *sgtrect3, DVECTOR *screenCoord
 
 extern int GV_PauseLevel_800AB928;
 
-void sgtrect3_act_helper_80070CAC(Actor_sgtrect3 *sgtrect3)
+void sgtrect3_act_helper_80070CAC(SgtRect3Work *work)
 {
     int     vecLen;
     SVECTOR vector2;
@@ -426,29 +426,29 @@ void sgtrect3_act_helper_80070CAC(Actor_sgtrect3 *sgtrect3)
     {
         return;
     }
-    if (sgtrect3->field_21B4 == 0)
+    if (work->field_21B4 == 0)
     {
-        sgtrect3->field_21B0++;
-        if (!sgtrect3->field_30_target)
+        work->field_21B0++;
+        if (!work->field_30_target)
         {
             return;
         }
 
         vector = (dword_8009F46C != 0) ? svector_8009F478 : GM_PlayerPosition_800ABA10;
 
-        GV_SubVec3_80016D40(&sgtrect3->field_30_target->center, &vector, &vector2);
+        GV_SubVec3_80016D40(&work->field_30_target->center, &vector, &vector2);
         vecLen = GV_VecLen3_80016D80(&vector2);
         vecLen = (vecLen * 3) / 2000;
         if (vecLen == 0)
         {
             vecLen = 1;
         }
-        if (sgtrect3->field_21B0 % vecLen != 0)
+        if (work->field_21B0 % vecLen != 0)
         {
             return;
         }
     }
-    else if (!sgtrect3->field_30_target)
+    else if (!work->field_30_target)
     {
         return;
     }
@@ -457,32 +457,32 @@ void sgtrect3_act_helper_80070CAC(Actor_sgtrect3 *sgtrect3)
 
 extern TARGET *target_800BDF00;
 
-void sgtrect3_act_80070E14(Actor_sgtrect3 *sgtrect3)
+void sgtrect3_act_80070E14(SgtRect3Work *work)
 {
     DVECTOR    screenCoords[32];
     TARGET *targets[32];
     ushort     offsets[32];
 
-    if (sgtrect3->field_24 != *sgtrect3->field_20)
+    if (work->field_24 != *work->field_20)
     {
-        GV_DestroyActor_800151C8((GV_ACT *)sgtrect3);
+        GV_DestroyActor_800151C8((GV_ACT *)work);
         return;
     }
 
     target_800BDF00 = NULL;
     sgtrect3_act_helper_8007009C();
-    sgtrect3_act_helper_8007020C(sgtrect3, screenCoords, targets, offsets);
-    sgtrect3_act_helper_80070AB0(sgtrect3, screenCoords, targets, offsets);
-    sgtrect3_act_helper_80070CAC(sgtrect3);
-    target_800BDF00 = sgtrect3->field_30_target;
+    sgtrect3_act_helper_8007020C(work, screenCoords, targets, offsets);
+    sgtrect3_act_helper_80070AB0(work, screenCoords, targets, offsets);
+    sgtrect3_act_helper_80070CAC(work);
+    target_800BDF00 = work->field_30_target;
 }
 
-void sgtrect3_kill_80070EC0(Actor_sgtrect3 *actor_sgtrect3)
+void sgtrect3_kill_80070EC0(SgtRect3Work *actor_sgtrect3)
 {
     byte_8009F5F8[0] = 0;
 }
 
-void sgtrect3_loader_helper_80070ECC(Actor_sgtrect3 *sgtrect3, unsigned int rgb)
+void sgtrect3_loader_helper_80070ECC(SgtRect3Work *work, unsigned int rgb)
 {
     int      index;
     int      lineIndex;
@@ -490,7 +490,7 @@ void sgtrect3_loader_helper_80070ECC(Actor_sgtrect3 *sgtrect3, unsigned int rgb)
 
     for (index = 0; index < 2; index++)
     {
-        line = sgtrect3->field_1C3C_lines[index].field_0;
+        line = work->field_1C3C_lines[index].field_0;
         for (lineIndex = 0; lineIndex < 24; lineIndex++, line++)
         {
             *(unsigned int *)&line->r0 = rgb; // LCOPY() doesn't work here.
@@ -501,22 +501,22 @@ void sgtrect3_loader_helper_80070ECC(Actor_sgtrect3 *sgtrect3, unsigned int rgb)
 
     for (index = 0; index < 12; index++)
     {
-        sgtrect3->field_217C[index] = 0;
+        work->field_217C[index] = 0;
     }
 }
 
-int sgtrect3_loader_80070F4C(Actor_sgtrect3 *sgtrect3, unsigned int *rgb2)
+int sgtrect3_loader_80070F4C(SgtRect3Work *work, unsigned int *rgb2)
 {
     int       outerIndex;
     int       innerIndex;
     DR_TPAGE *tPageIter_21B8;
     DR_TPAGE *tPageIter_23B8;
 
-    tPageIter_23B8 = &sgtrect3->field_23B8_prim[0];
+    tPageIter_23B8 = &work->field_23B8_prim[0];
 
     for (outerIndex = 0; outerIndex < 2; outerIndex++, tPageIter_23B8++)
     {
-        tPageIter_21B8 = sgtrect3->field_21B8[outerIndex].field_0;
+        tPageIter_21B8 = work->field_21B8[outerIndex].field_0;
 
         for (innerIndex = 0; innerIndex < 32; innerIndex++, tPageIter_21B8++)
         {
@@ -526,51 +526,51 @@ int sgtrect3_loader_80070F4C(Actor_sgtrect3 *sgtrect3, unsigned int *rgb2)
         SetDrawTPage(tPageIter_23B8, 0, 1, 32);
     }
 
-    sgtrect3_loader_helper_80070ECC(sgtrect3, rgb2[1]);
+    sgtrect3_loader_helper_80070ECC(work, rgb2[1]);
 
     return 0;
 }
 
-Actor_sgtrect3 *NewSgtRect3_80071010(short *param_1, short param_2, unsigned int *rgb2, int param_4)
+SgtRect3Work *NewSgtRect3_80071010(short *param_1, short param_2, unsigned int *rgb2, int param_4)
 {
-    Actor_sgtrect3 *sgtrect3;
+    SgtRect3Work *work;
 
     if (byte_8009F5F8[0])
     {
         return NULL;
     }
 
-    sgtrect3 = (Actor_sgtrect3 *)GV_NewActor_800150E4(7, sizeof(Actor_sgtrect3));
-    if (!sgtrect3)
+    work = (SgtRect3Work *)GV_NewActor_800150E4(7, sizeof(SgtRect3Work));
+    if (!work)
     {
         return NULL;
     }
 
-    GV_SetNamedActor_8001514C((GV_ACT *)sgtrect3, (TActorFunction)sgtrect3_act_80070E14,
+    GV_SetNamedActor_8001514C((GV_ACT *)work, (TActorFunction)sgtrect3_act_80070E14,
                               (TActorFunction)sgtrect3_kill_80070EC0, "sgtrect3.c");
 
-    if (sgtrect3_loader_80070F4C(sgtrect3, rgb2) < 0)
+    if (sgtrect3_loader_80070F4C(work, rgb2) < 0)
     {
-        GV_DestroyActor_800151C8((GV_ACT *)sgtrect3);
+        GV_DestroyActor_800151C8((GV_ACT *)work);
         return NULL;
     }
 
     byte_8009F5F8[0] = 1;
-    sgtrect3->field_28_rgb.rgbWord = rgb2[0];
-    sgtrect3->field_2C_rgb.rgbWord = rgb2[1];
-    sgtrect3->field_20 = param_1;
-    sgtrect3->field_24 = param_2;
+    work->field_28_rgb.rgbWord = rgb2[0];
+    work->field_2C_rgb.rgbWord = rgb2[1];
+    work->field_20 = param_1;
+    work->field_24 = param_2;
 
     if (amissile_alive_8009F490 == 0)
     {
         target_800BDF00 = NULL;
     }
 
-    sgtrect3->field_34_count = 0;
-    sgtrect3->field_38 = 0;
-    sgtrect3->field_21B4 = param_4;
-    sgtrect3->field_21B0 = 0;
-    sgtrect3->field_30_target = target_800BDF00;
+    work->field_34_count = 0;
+    work->field_38 = 0;
+    work->field_21B4 = param_4;
+    work->field_21B0 = 0;
+    work->field_30_target = target_800BDF00;
 
-    return sgtrect3;
+    return work;
 }

--- a/src/Thing/sgtrect3.h
+++ b/src/Thing/sgtrect3.h
@@ -36,7 +36,7 @@ typedef union rgbUnion {
     char         rgbChars[4]; // 4th is padding.
 } rgbUnion;
 
-typedef struct Actor_sgtrect3
+typedef struct SgtRect3Work
 {
     GV_ACT         actor;
     short         *field_20;
@@ -56,10 +56,10 @@ typedef struct Actor_sgtrect3
     int            field_21B4;
     sgtrect3_0x100 field_21B8[2];
     DR_TPAGE       field_23B8_prim[2];
-} Actor_sgtrect3;
+} SgtRect3Work;
 
-Actor_sgtrect3 *NewSgtRect3_80071010(short *param_1, short param_2, unsigned int *rgb2, int param_4);
-void            sgtrect3_act_helper_80070820(void *ot, LINE_F3 *lineF3Arr, LINE_F2 *lineF2Arr, DVECTOR *screenCoords,
-                                             ushort offset, unsigned int rgb);
+SgtRect3Work *NewSgtRect3_80071010(short *param_1, short param_2, unsigned int *rgb2, int param_4);
+void sgtrect3_act_helper_80070820(void *ot, LINE_F3 *lineF3Arr, LINE_F2 *lineF2Arr, DVECTOR *screenCoords,
+                                  ushort offset, unsigned int rgb);
 
 #endif // _SGTRECT3_H_

--- a/src/Thing/sight.c
+++ b/src/Thing/sight.c
@@ -10,7 +10,7 @@ int  dword_8009F600 = 0;
 int  dword_8009F604 = -1;
 int  dword_8009F608 = 0;
 
-void sight_act_helper_8007111C(Actor_Sight *sight)
+void sight_act_helper_8007111C(SightWork *work)
 {
     int     message_result;
     GV_MSG *message;
@@ -52,10 +52,9 @@ static inline int calc(int diff, int offset)
 // Handles the animation of the HUD when transitioning into the scope view or the box or gas mask's first-person view.
 // Various permutations show the logic is sound but getting it to match is hard and is essentially forced here by the
 // use of absurd intermediates.
-void sight_800711C0(Actor_Sight *sight, int frameCount, void *primitive, int primOffsetIndicesIndex,
+void sight_800711C0(SightWork *work, int frameCount, void *primitive, int primOffsetIndicesIndex,
                     SightPrimOffsetIndices *primOffsetIndices, SightPrimOffsetInfo *primOffsetInfo, int primOffset,
                     unsigned int flags)
-
 {
     void                *currentPrimX;
     char                 code;
@@ -85,7 +84,7 @@ void sight_800711C0(Actor_Sight *sight, int frameCount, void *primitive, int pri
     gouraudShaded = (code >> 2) & 4;
     step = gouraudShaded + 4;
 
-    primBuf = sight->field_34_primitiveBufferInfo->field_8_primitiveBuffer + primOffset + 8;
+    primBuf = work->field_34_primitiveBufferInfo->field_8_primitiveBuffer + primOffset + 8;
 
     for (; index < 4; primBuf += step, currentPrimY += step, currentPrimX += step, index++)
     {
@@ -126,7 +125,7 @@ void sight_800711C0(Actor_Sight *sight, int frameCount, void *primitive, int pri
 }
 
 // Called every frame when in the first-person view with the thermal goggles or night-vision goggles.
-void sight_act_helper_80071320(Actor_Sight *sight, void *targetPrim, short *xyOffsetBuffer, int primOffset)
+void sight_act_helper_80071320(SightWork *work, void *targetPrim, short *xyOffsetBuffer, int primOffset)
 {
     void *posX;
     void *posY;
@@ -142,9 +141,9 @@ void sight_act_helper_80071320(Actor_Sight *sight, void *targetPrim, short *xyOf
     int   step;
 
     posX = targetPrim + 8;
-    if (sight->field_50 < 3)
+    if (work->field_50 < 3)
     {
-        primBuf = sight->field_34_primitiveBufferInfo->field_8_primitiveBuffer;
+        primBuf = work->field_34_primitiveBufferInfo->field_8_primitiveBuffer;
         copiedPrim = primBuf + primOffset;
 
         code = getcode(targetPrim);
@@ -219,7 +218,7 @@ void sight_act_helper_80071320(Actor_Sight *sight, void *targetPrim, short *xyOf
 }
 
 // Called when transitioning into the first-person view with any relevant items.
-void sight_act_helper_800713FC(Actor_Sight *sight, int clock)
+void sight_act_helper_800713FC(SightWork *work, int clock)
 {
     void                     *primBuf;
     unsigned int             *primBufIter;
@@ -233,10 +232,10 @@ void sight_act_helper_800713FC(Actor_Sight *sight, int clock)
     void                     *currentPrim;
     int                       tag;
 
-    primBuf = sight->field_38_primitiveDoubleBuffer[clock];
+    primBuf = work->field_38_primitiveDoubleBuffer[clock];
     primBufIter = primBuf;
 
-    primBufInfo = sight->field_34_primitiveBufferInfo;
+    primBufInfo = work->field_34_primitiveBufferInfo;
     ancillaryInfo = primBufInfo->field_4_ancillaryInfo;
     numPrims = primBufInfo->field_3_primCount;
     primBufSize = primBufInfo->field_0_primitiveBufferSize;
@@ -273,7 +272,7 @@ extern int GM_CurrentMap_800AB9B0;
 extern int GM_PlayerStatus_800ABA50;
 extern int GV_PauseLevel_800AB928;
 
-void sight_act_800714EC(Actor_Sight *sight)
+void sight_act_800714EC(SightWork *work)
 {
     SightPrimitiveBufferInfo *primBufInfo;
     SightPrimBufInfoStruct   *ancillaryInfo;
@@ -302,66 +301,66 @@ void sight_act_800714EC(Actor_Sight *sight)
     char                      code;
     short                    *xyOffsetBuffer;
 
-    if (sight->field_20_itemId != *sight->field_24_itemEquippedIndicator)
+    if (work->field_20_itemId != *work->field_24_itemEquippedIndicator)
     {
-        GV_DestroyActor_800151C8((GV_ACT *)sight);
+        GV_DestroyActor_800151C8((GV_ACT *)work);
         return;
     }
 
-    sight->field_54_maybeFlags &= 0xffff7fff;
+    work->field_54_maybeFlags &= 0xffff7fff;
 
-    if (sight->field_58_clock != GV_Clock_800AB920 && (++sight->field_5A_maybeFlags & 0xffff) == 2)
+    if (work->field_58_clock != GV_Clock_800AB920 && (++work->field_5A_maybeFlags & 0xffff) == 2)
     {
-        sight->field_54_maybeFlags |= 0x8000;
-        sight->field_5A_maybeFlags = 0;
+        work->field_54_maybeFlags |= 0x8000;
+        work->field_5A_maybeFlags = 0;
     }
 
-    sight->field_58_clock = GV_Clock_800AB920;
-    sight_act_helper_8007111C(sight);
-    sight->field_28_currentMap = GM_CurrentMap_800AB9B0;
+    work->field_58_clock = GV_Clock_800AB920;
+    sight_act_helper_8007111C(work);
+    work->field_28_currentMap = GM_CurrentMap_800AB9B0;
 
-    primBufInfo = sight->field_34_primitiveBufferInfo;
+    primBufInfo = work->field_34_primitiveBufferInfo;
     primCount = primBufInfo->field_3_primCount;
     ancillaryInfo = primBufInfo->field_4_ancillaryInfo;
 
-    tPageBuf = sight->field_44_tPageDoubleBuffer[GV_Clock_800AB920];
+    tPageBuf = work->field_44_tPageDoubleBuffer[GV_Clock_800AB920];
 
-    frameCount = sight->field_2C_frameCount;
-    field30 = sight->field_30;
+    frameCount = work->field_2C_frameCount;
+    field30 = work->field_30;
     ot = DG_ChanlOTag(1);
 
     primOffsetIndicesArray = primBufInfo->field_C_primOffsetIndicesArray;
     primOffsetInfoArray = primBufInfo->field_10_primOffsetInfoArray;
-    primBuf = sight->field_38_primitiveDoubleBuffer[GV_Clock_800AB920];
+    primBuf = work->field_38_primitiveDoubleBuffer[GV_Clock_800AB920];
 
-    if (field30 == 0 && primBufInfo->field_2 < sight->field_2C_frameCount)
+    if (field30 == 0 && primBufInfo->field_2 < work->field_2C_frameCount)
     {
         flag = (0x100 << GV_Clock_800AB920);
-        if (!(sight->field_54_maybeFlags & flag))
+        if (!(work->field_54_maybeFlags & flag))
         {
-            sight->field_54_maybeFlags |= flag;
-            sight_act_helper_800713FC(sight, GV_Clock_800AB920);
+            work->field_54_maybeFlags |= flag;
+            sight_act_helper_800713FC(work, GV_Clock_800AB920);
         }
-        if ((sight->field_54_maybeFlags & 0x300) == 0x300)
+        if ((work->field_54_maybeFlags & 0x300) == 0x300)
         {
-            sight->field_30 = 1;
+            work->field_30 = 1;
         }
     }
 
-    xyOffsetBuffer = sight->field_4C_xyOffsetBuffer;
-    field54Flags = sight->field_54_maybeFlags;
+    xyOffsetBuffer = work->field_4C_xyOffsetBuffer;
+    field54Flags = work->field_54_maybeFlags;
     if (xyOffsetBuffer != (short *)0x0)
     {
         if (xyOffsetBuffer[0] == 0 && xyOffsetBuffer[1] == 0)
         {
-            if (++sight->field_50 >= 3 && !(field54Flags & 0x8000))
+            if (++work->field_50 >= 3 && !(field54Flags & 0x8000))
             {
-                sight->field_50 = 2;
+                work->field_50 = 2;
             }
         }
         else
         {
-            sight->field_50 = 0;
+            work->field_50 = 0;
         }
     }
 
@@ -384,15 +383,15 @@ void sight_act_800714EC(Actor_Sight *sight)
 
         if (frameCountPositive != 0 && offsetIndicesIndex != 0)
         {
-            sight_800711C0(sight, frameCount, offsetPrimBuf, offsetIndicesIndex, primOffsetIndicesArray,
+            sight_800711C0(work, frameCount, offsetPrimBuf, offsetIndicesIndex, primOffsetIndicesArray,
                            primOffsetInfoArray, primOffset, field54Flags);
         }
 
         if (ancField1Anded != 0)
         {
-            infoField14 = &sight->field_34_primitiveBufferInfo->field_14_array[ancField1Anded - 1];
+            infoField14 = &work->field_34_primitiveBufferInfo->field_14_array[ancField1Anded - 1];
             infoField14Field0 = infoField14->field_0;
-            frameCountMod = sight->field_2C_frameCount % infoField14Field0;
+            frameCountMod = work->field_2C_frameCount % infoField14Field0;
             infoField14Field1 = infoField14->field_1;
             if (frameCountMod < infoField14Field1)
             {
@@ -401,7 +400,7 @@ void sight_act_800714EC(Actor_Sight *sight)
         }
         if (field30 != 0 && xyOffsetBuffer != (short *)0x0)
         {
-            sight_act_helper_80071320(sight, offsetPrimBuf, xyOffsetBuffer, primOffset);
+            sight_act_helper_80071320(work, offsetPrimBuf, xyOffsetBuffer, primOffset);
         }
         tag = *(int *)offsetPrimBuf;
         if (tag == 0xff)
@@ -430,24 +429,24 @@ void sight_act_800714EC(Actor_Sight *sight)
         }
     }
 
-    if (sight->field_2C_frameCount < 0x7fff0000 && GV_PauseLevel_800AB928 == 0)
+    if (work->field_2C_frameCount < 0x7fff0000 && GV_PauseLevel_800AB928 == 0)
     {
-        sight->field_2C_frameCount++;
+        work->field_2C_frameCount++;
     }
 
     menu_Text_Init_80038B98();
 }
 
-void sight_kill_800719C8(Actor_Sight *sight)
+void sight_kill_800719C8(SightWork *work)
 {
-    if (*sight->field_38_primitiveDoubleBuffer)
+    if (*work->field_38_primitiveDoubleBuffer)
     {
-        GV_DelayedFree_80016254(*sight->field_38_primitiveDoubleBuffer);
+        GV_DelayedFree_80016254(*work->field_38_primitiveDoubleBuffer);
     }
 
-    if (*sight->field_44_tPageDoubleBuffer)
+    if (*work->field_44_tPageDoubleBuffer)
     {
-        GV_DelayedFree_80016254(*sight->field_44_tPageDoubleBuffer);
+        GV_DelayedFree_80016254(*work->field_44_tPageDoubleBuffer);
     }
 
     if ((0 < dword_8009F600) && (--dword_8009F600 == 0))
@@ -458,7 +457,7 @@ void sight_kill_800719C8(Actor_Sight *sight)
     dword_8009F608 &= ~1;
 }
 
-int sight_loader_80071A54(Actor_Sight *sight, int hashedFileName, short *itemEquippedIndicator, short itemId,
+int sight_loader_80071A54(SightWork *work, int hashedFileName, short *itemEquippedIndicator, short itemId,
                           short *xyOffsetBuffer)
 {
     // Primitive buffer info.
@@ -494,10 +493,10 @@ int sight_loader_80071A54(Actor_Sight *sight, int hashedFileName, short *itemEqu
     SightPrimOffsetInfo    *primOffsetInfo;
     char                    offsetIndicesIndex;
 
-    flags = sight->field_54_maybeFlags;
+    flags = work->field_54_maybeFlags;
     cacheId = GV_CacheID_800152DC(hashedFileName, 's');
     info = (SightPrimitiveBufferInfo *)GV_GetCache_8001538C(cacheId);
-    sight->field_34_primitiveBufferInfo = info;
+    work->field_34_primitiveBufferInfo = info;
 
     if (!info)
     {
@@ -511,7 +510,7 @@ int sight_loader_80071A54(Actor_Sight *sight, int hashedFileName, short *itemEqu
     tPageCount = 0;
     primOffsetInfo = info->field_10_primOffsetInfoArray;
     primitiveBuffer = (unsigned int *)GV_Malloc_8001620C(primitiveBufferSize * 2);
-    sight->field_38_primitiveDoubleBuffer[0] = primitiveBuffer;
+    work->field_38_primitiveDoubleBuffer[0] = primitiveBuffer;
 
     if (!primitiveBuffer)
     {
@@ -519,8 +518,8 @@ int sight_loader_80071A54(Actor_Sight *sight, int hashedFileName, short *itemEqu
     }
     else
     {
-        sight->field_38_primitiveDoubleBuffer[1] = (unsigned int *)(((char *)primitiveBuffer) + primitiveBufferSize);
-        originBuffer = sight->field_34_primitiveBufferInfo->field_8_primitiveBuffer;
+        work->field_38_primitiveDoubleBuffer[1] = (unsigned int *)(((char *)primitiveBuffer) + primitiveBufferSize);
+        originBuffer = work->field_34_primitiveBufferInfo->field_8_primitiveBuffer;
         targetBuffer = primitiveBuffer;
         firstPrimitiveBuffer = targetBuffer;
         firstPrimitiveBufferCopy = firstPrimitiveBuffer;
@@ -548,7 +547,7 @@ int sight_loader_80071A54(Actor_Sight *sight, int hashedFileName, short *itemEqu
                 {
                     // Handle the animation of the HUD when transitioning into the scope view or the box or gas mask's
                     // first-person view.
-                    sight_800711C0(sight, -1, currentPrimitive, ancillaryInfo->field_0_offsetIndicesIndex,
+                    sight_800711C0(work, -1, currentPrimitive, ancillaryInfo->field_0_offsetIndicesIndex,
                                    primOffsetIndices, primOffsetInfo, 0, 0);
                 }
             }
@@ -572,22 +571,22 @@ int sight_loader_80071A54(Actor_Sight *sight, int hashedFileName, short *itemEqu
 
         if ((flags & 2) != 0)
         {
-            sight->field_2C_frameCount = (sight->field_34_primitiveBufferInfo->field_2) + 2;
+            work->field_2C_frameCount = (work->field_34_primitiveBufferInfo->field_2) + 2;
         }
 
         else
         {
-            sight->field_2C_frameCount = 0;
+            work->field_2C_frameCount = 0;
         }
 
-        sight->field_30 = (flags >> 1) & 1;
-        sight->field_20_itemId = itemId ^ 0;
-        sight->field_24_itemEquippedIndicator = itemEquippedIndicator;
+        work->field_30 = (flags >> 1) & 1;
+        work->field_20_itemId = itemId ^ 0;
+        work->field_24_itemEquippedIndicator = itemEquippedIndicator;
 
         if (tPageCount == 0)
         {
-            sight->field_44_tPageDoubleBuffer[0] = (DR_TPAGE *)0x0;
-            sight->field_44_tPageDoubleBuffer[1] = (DR_TPAGE *)0x0;
+            work->field_44_tPageDoubleBuffer[0] = (DR_TPAGE *)0x0;
+            work->field_44_tPageDoubleBuffer[1] = (DR_TPAGE *)0x0;
         }
 
         else
@@ -599,40 +598,40 @@ int sight_loader_80071A54(Actor_Sight *sight, int hashedFileName, short *itemEqu
                 return -1;
             }
 
-            sight->field_44_tPageDoubleBuffer[0] = tPageMem;
-            sight->field_44_tPageDoubleBuffer[1] = tPageMem + tPageCount;
+            work->field_44_tPageDoubleBuffer[0] = tPageMem;
+            work->field_44_tPageDoubleBuffer[1] = tPageMem + tPageCount;
         }
 
-        sight->field_40 = tPageCount;
-        sight->field_4C_xyOffsetBuffer = xyOffsetBuffer;
-        sight->field_50 = 0;
-        sight->field_54_maybeFlags = 0;
-        sight->field_58_clock = GV_Clock_800AB920;
-        sight->field_5A_maybeFlags = 0;
+        work->field_40 = tPageCount;
+        work->field_4C_xyOffsetBuffer = xyOffsetBuffer;
+        work->field_50 = 0;
+        work->field_54_maybeFlags = 0;
+        work->field_58_clock = GV_Clock_800AB920;
+        work->field_5A_maybeFlags = 0;
         return 0;
     }
 }
 
-Actor_Sight *NewSight_80071CDC(int hashedFileName0, int hashedFileName1, short *itemEquippedIndicator, short itemId,
-                               short *xyOffsetBuffer)
+SightWork *NewSight_80071CDC(int hashedFileName0, int hashedFileName1, short *itemEquippedIndicator, short itemId,
+                             short *xyOffsetBuffer)
 {
-    Actor_Sight *sight = (Actor_Sight *)0x0;
+    SightWork *work = (SightWork *)NULL;
 
     if (dword_8009F604 != -1 && dword_8009F604 != hashedFileName1)
     {
-        return sight;
+        return work;
     }
 
-    sight = (Actor_Sight *)GV_NewActor_800150E4(7, sizeof(Actor_Sight));
-    if (sight)
+    work = (SightWork *)GV_NewActor_800150E4(7, sizeof(SightWork));
+    if (work)
     {
-        GV_SetNamedActor_8001514C((GV_ACT *)sight, (TActorFunction)sight_act_800714EC,
+        GV_SetNamedActor_8001514C((GV_ACT *)work, (TActorFunction)sight_act_800714EC,
                                   (TActorFunction)sight_kill_800719C8, "sight.c");
-        sight->field_54_maybeFlags = 0;
+        work->field_54_maybeFlags = 0;
 
-        if (sight_loader_80071A54(sight, hashedFileName0, itemEquippedIndicator, itemId, xyOffsetBuffer) < 0)
+        if (sight_loader_80071A54(work, hashedFileName0, itemEquippedIndicator, itemId, xyOffsetBuffer) < 0)
         {
-            GV_DestroyActor_800151C8((GV_ACT *)sight);
+            GV_DestroyActor_800151C8((GV_ACT *)work);
             return 0;
         }
 
@@ -640,28 +639,28 @@ Actor_Sight *NewSight_80071CDC(int hashedFileName0, int hashedFileName1, short *
         dword_8009F604 = hashedFileName1;
     }
 
-    return sight;
+    return work;
 }
 
-Actor_Sight *sight_init_80071DC8(int hashedFileName, short *xyOffsetBuffer)
+SightWork *sight_init_80071DC8(int hashedFileName, short *xyOffsetBuffer)
 {
-    Actor_Sight *sight = (Actor_Sight *)0x0;
+    SightWork *work = (SightWork *)NULL;
 
     if (dword_8009F604 != -1 && dword_8009F604 != hashedFileName)
     {
-        return sight;
+        return work;
     }
 
-    sight = (Actor_Sight *)GV_NewActor_800150E4(7, sizeof(Actor_Sight));
-    if (sight)
+    work = (SightWork *)GV_NewActor_800150E4(7, sizeof(SightWork));
+    if (work)
     {
-        GV_SetNamedActor_8001514C((GV_ACT *)sight, (TActorFunction)sight_act_800714EC,
+        GV_SetNamedActor_8001514C((GV_ACT *)work, (TActorFunction)sight_act_800714EC,
                                   (TActorFunction)sight_kill_800719C8, "sight.c");
-        sight->field_54_maybeFlags = 0;
+        work->field_54_maybeFlags = 0;
 
-        if (sight_loader_80071A54(sight, hashedFileName, &word_8009F5FC, 1, xyOffsetBuffer) < 0)
+        if (sight_loader_80071A54(work, hashedFileName, &word_8009F5FC, 1, xyOffsetBuffer) < 0)
         {
-            GV_DestroyActor_800151C8((GV_ACT *)sight);
+            GV_DestroyActor_800151C8((GV_ACT *)work);
             return 0;
         }
 
@@ -670,29 +669,29 @@ Actor_Sight *sight_init_80071DC8(int hashedFileName, short *xyOffsetBuffer)
         word_8009F5FC = 1;
     }
 
-    return sight;
+    return work;
 }
 
-Actor_Sight *sight_init_80071EA8(int hashedFileName0, int hashedFileName1, short *itemEquippedIndicator, short itemId,
-                                 short *xyOffsetBuffer)
+SightWork *sight_init_80071EA8(int hashedFileName0, int hashedFileName1, short *itemEquippedIndicator, short itemId,
+                               short *xyOffsetBuffer)
 {
-    Actor_Sight *sight = (Actor_Sight *)0x0;
+    SightWork *work = (SightWork *)NULL;
 
     if (dword_8009F604 != -1 && dword_8009F604 != hashedFileName1)
     {
-        return sight;
+        return work;
     }
 
-    sight = (Actor_Sight *)GV_NewActor_800150E4(7, sizeof(Actor_Sight));
-    if (sight)
+    work = (SightWork *)GV_NewActor_800150E4(7, sizeof(SightWork));
+    if (work)
     {
-        GV_SetNamedActor_8001514C((GV_ACT *)sight, (TActorFunction)sight_act_800714EC,
+        GV_SetNamedActor_8001514C((GV_ACT *)work, (TActorFunction)sight_act_800714EC,
                                   (TActorFunction)sight_kill_800719C8, "sight.c");
-        sight->field_54_maybeFlags = 2;
+        work->field_54_maybeFlags = 2;
 
-        if (sight_loader_80071A54(sight, hashedFileName0, itemEquippedIndicator, itemId, xyOffsetBuffer) < 0)
+        if (sight_loader_80071A54(work, hashedFileName0, itemEquippedIndicator, itemId, xyOffsetBuffer) < 0)
         {
-            GV_DestroyActor_800151C8((GV_ACT *)sight);
+            GV_DestroyActor_800151C8((GV_ACT *)work);
             return 0;
         }
 
@@ -700,38 +699,38 @@ Actor_Sight *sight_init_80071EA8(int hashedFileName0, int hashedFileName1, short
         dword_8009F604 = hashedFileName1;
     }
 
-    return sight;
+    return work;
 }
 
-Actor_Sight *sight_init_80071F98(int hashedFileName, short *xyOffsetBuffer)
+SightWork *sight_init_80071F98(int hashedFileName, short *xyOffsetBuffer)
 {
-    Actor_Sight *sight = (Actor_Sight *)0x0;
+    SightWork *work = (SightWork *)NULL;
 
     if (dword_8009F604 != -1 && dword_8009F604 != hashedFileName)
     {
-        return sight;
+        return work;
     }
 
     dword_8009F600++;
     dword_8009F604 = hashedFileName;
 
-    sight = (Actor_Sight *)GV_NewActor_800150E4(7, sizeof(Actor_Sight));
-    if (sight)
+    work = (SightWork *)GV_NewActor_800150E4(7, sizeof(SightWork));
+    if (work)
     {
-        GV_SetNamedActor_8001514C((GV_ACT *)sight, (TActorFunction)sight_act_800714EC,
+        GV_SetNamedActor_8001514C((GV_ACT *)work, (TActorFunction)sight_act_800714EC,
                                   (TActorFunction)sight_kill_800719C8, "sight.c");
-        sight->field_54_maybeFlags = 2;
+        work->field_54_maybeFlags = 2;
 
-        if (sight_loader_80071A54(sight, hashedFileName, &word_8009F5FC, 1, xyOffsetBuffer) < 0)
+        if (sight_loader_80071A54(work, hashedFileName, &word_8009F5FC, 1, xyOffsetBuffer) < 0)
         {
-            GV_DestroyActor_800151C8((GV_ACT *)sight);
+            GV_DestroyActor_800151C8((GV_ACT *)work);
             return 0;
         }
 
         word_8009F5FC = 1;
     }
 
-    return sight;
+    return work;
 }
 
 void sub_80072074()

--- a/src/Thing/sight.h
+++ b/src/Thing/sight.h
@@ -72,7 +72,7 @@ typedef struct SightTextPseudoPrim
 // - the night-vision goggles;
 // - the camera;
 // - the Stinger missile.
-typedef struct Actor_Sight
+typedef struct SightWork
 {
     GV_ACT                    actor;
     int                       field_20_itemId;
@@ -89,16 +89,16 @@ typedef struct Actor_Sight
     int                       field_54_maybeFlags;
     unsigned short            field_58_clock;
     short                     field_5A_maybeFlags;
-} Actor_Sight;
+} SightWork;
 
-STATIC_ASSERT_SIZE(Actor_Sight, 0x5c);
+STATIC_ASSERT_SIZE(SightWork, 0x5c);
 
-void sight_act_800714EC(Actor_Sight *sight);
+void sight_act_800714EC(SightWork *work);
 
-Actor_Sight * NewSight_80071CDC(int hashedFileName0, int hashedFileName1, short *itemEquippedIndicator, short itemId,
-                                short *xyOffsetBuffer);
+SightWork *NewSight_80071CDC(int hashedFileName0, int hashedFileName1, short *itemEquippedIndicator, short itemId,
+                             short *xyOffsetBuffer);
 
-Actor_Sight * sight_init_80071EA8(int hashedFileName0, int hashedFileName1, short *itemEquippedIndicator, short itemId,
-                                  short *xyOffsetBuffer);
+SightWork *sight_init_80071EA8(int hashedFileName0, int hashedFileName1, short *itemEquippedIndicator, short itemId,
+                               short *xyOffsetBuffer);
 
 #endif // _SIGHT_H_

--- a/src/Weapon/rfsight.h
+++ b/src/Weapon/rfsight.h
@@ -6,7 +6,7 @@
 
 // PSG1 first person HUD
 
-typedef Actor_Sight * (*rfsight_pfn_t)(int, int, short *, short, short *);
+typedef SightWork * (*rfsight_pfn_t)(int, int, short *, short, short *);
 
 typedef struct _RfSightWork
 {

--- a/src/data/bss.c
+++ b/src/data/bss.c
@@ -1,3 +1,5 @@
+#define __BSSDEFINE__
+
 #include "linker.h"
 #include "libfs/libfs.h"
 #include "libgv/libgv.h"

--- a/src/data/bss.c
+++ b/src/data/bss.c
@@ -180,7 +180,7 @@ int BSS             dword_800B9358; // 0x4 (4) bytes
 gap                                     gap_800B935C[0x4]; // 4 bytes
 
 unsigned char BSS   gPrimBackingBuffers_800B9360[2][8192]; // 0x4000 (16384) bytes
-Actor_MenuMan BSS   gMenuMan_800BD360; // 0x220 (544) bytes
+MenuWork BSS        gMenuWork_800BD360; // 0x220 (544) bytes
 MATRIX BSS          gRadarScaleMatrix_800BD580; // 0x20 (32) bytes
 PANEL_TEXTURE BSS   gMenuLeftItems_800BD5A0[MENU_ITEM_COUNT]; // 0x1A4 (420) bytes
 

--- a/src/data/bss.c
+++ b/src/data/bss.c
@@ -29,8 +29,8 @@
 // var declarations. put everything else in a header. all comments below the line will also be deleted.
 // you must use "BSS" instead of SECTION, and for EVERY var.
 
-// note: if any included headers has an extern to the same vars defined here, matches will fail. never put extern
-// data in a header.
+// NOTE: If any included headers has an extern to the same vars defined here, matches will fail.
+// Never put extern data in a header without wrapping it with #ifndef __BSSDEFINE__!!
 
 // --------------------------------------------------------------------------------------------------------------------
 

--- a/src/data/bss.c
+++ b/src/data/bss.c
@@ -296,8 +296,10 @@ int BSS         dword_800BDFC4; // 0x4 (4) bytes
 
 gap                                     gap_800BDFC8[0x800]; // 2048 bytes
 
-unsigned int BSS    sd_main_stack_800BE7C8[512]; // 0x800 (2048) bytes
-int BSS             sd_int_stack_800BEFC8; // 0x4 (4) bytes
+/* sound.lib */
+
+unsigned long BSS   sd_main_stack_800BE7C8[512]; // 0x800 (2048) bytes
+unsigned long BSS   sd_int_stack_800BEFC8; // 0x4 (4) bytes
 int BSS             dword_800BEFCC; // 0x4 (4) bytes
 
 gap                                     gap_800BEFD0[0x4]; // 4 bytes
@@ -311,7 +313,7 @@ char *BSS           stream_data_ptr_800BEFE4; // 0x4 (4) bytes
 int BSS             str_mono_offset_800BEFE8; // 0x4 (4) bytes
 int BSS             dword_800BEFEC; // 0x4 (4) bytes
 int BSS             str_mute_fg_800BEFF0; // 0x4 (4) bytes
-int BSS             str_int_ctr_800BEFF4; // 0x4 (4) bytes
+unsigned int BSS    str_int_ctr_800BEFF4; // 0x4 (4) bytes
 int BSS             dword_800BEFF8; // 0x4 (4) bytes
 #ifdef VR_EXE
 gap                                     vrgap1[0x4]; // 4 bytes
@@ -323,7 +325,7 @@ int BSS             se_tracks_800BF004; // 0x4 (4) bytes
 gap                                     vrgap2[0x4]; // 4 bytes
 #endif
 int BSS             dword_800BF008; // 0x4 (4) bytes
-int BSS             blank_data_addr_800BF00C; // 0x4 (4) bytes
+unsigned long BSS   blank_data_addr_800BF00C; // 0x4 (4) bytes
 char* BSS           cdload_buf_800BF010; // 0x4 (4) bytes
 int BSS             se_fp_800BF014; // 0x4 (4) bytes
 int BSS             sd_sng_code_buf_800BF018[16]; // 0x40 (64) bytes
@@ -334,12 +336,12 @@ int BSS             dword_800BF064; // 0x4 (4) bytes
 SEPLAYTBL BSS       se_playing_800BF068[8]; // 0x60 (96) bytes
 int BSS             spu_bgm_start_ptr_r_800BF0C8; // 0x4 (4) bytes
 int BSS             str_fadein_time_800BF0CC; // 0x4 (4) bytes
-unsigned int BSS    mdata1_800BF0D0; // 0x4 (4) bytes
-int BSS             mdata2_800BF0D4; // 0x4 (4) bytes
-int BSS             mdata3_800BF0D8; // 0x4 (4) bytes
-int BSS             mdata4_800BF0DC; // 0x4 (4) bytes
+unsigned long BSS   mdata1_800BF0D0; // 0x4 (4) bytes
+unsigned long BSS   mdata2_800BF0D4; // 0x4 (4) bytes
+unsigned long BSS   mdata3_800BF0D8; // 0x4 (4) bytes
+unsigned long BSS   mdata4_800BF0DC; // 0x4 (4) bytes
 SEPLAYTBL BSS       se_request_800BF0E0[8]; // 0x60 (96) bytes
-int BSS             spu_load_offset_800BF140; // 0x4 (4) bytes
+unsigned long BSS   spu_load_offset_800BF140; // 0x4 (4) bytes
 int BSS             vox_rev_on_800BF144; // 0x4 (4) bytes
 
 gap                                     gap_800BF148[0xC]; // 12 bytes
@@ -360,19 +362,19 @@ int BSS             stop_jouchuu_se_800BF1A0; // 0x4 (4) bytes
 int BSS             dword_800BF1A4; // 0x4 (4) bytes
 int BSS             dword_800BF1A8; // 0x4 (4) bytes
 int BSS             str_unplay_size_800BF1AC; // 0x4 (4) bytes
-int BSS             key_fg_800BF1B0; // 0x4 (4) bytes
+unsigned long BSS   key_fg_800BF1B0; // 0x4 (4) bytes
 
 gap                                     gap_800BF1B4[0x4]; // 4 bytes
 
 int BSS             se_pan_800BF1B8[8]; // 0x20 (32) bytes
 int BSS             sng_fp_800BF1D8; // 0x4 (4) bytes
 int BSS             str_mute_status_800BF1DC; // 0x4 (4) bytes
-WAVE_W* BSS         voice_tbl_800BF1E0; // 0x4 (4) bytes
+WAVE_W* BSS         wave_header_800BF1E0; // 0x4 (4) bytes
 
 gap                                     gap_800BF1E4[0x4]; // 4 bytes
 
 int BSS             bgm_idx_800BF1E8; // 0x4 (4) bytes
-unsigned int BSS    mtrack_800BF1EC; // 0x4 (4) bytes
+unsigned long BSS   mtrack_800BF1EC; // 0x4 (4) bytes
 int BSS             se_vol_800BF1F0[8]; // 0x20 (32) bytes
 int BSS             dword_800BF210; // 0x4 (4) bytes
 
@@ -381,22 +383,22 @@ gap                                     gap_800BF214[0x4]; // 4 bytes
 SpuVoiceAttr BSS    s_attr_800BF218; // 0x40 (64) bytes
 int BSS             str_fp_800BF258; // 0x4 (4) bytes
 int BSS             sng_fout_fg_800BF25C; // 0x4 (4) bytes
-int BSS             keyons_800BF260; // 0x4 (4) bytes
+unsigned long BSS   keyons_800BF260; // 0x4 (4) bytes
 int BSS             str_off_idx_800BF264; // 0x4 (4) bytes
 int BSS             str_mono_fg_800BF268; // 0x4 (4) bytes
 int BSS             str_fout_fg_800BF26C; // 0x4 (4) bytes
 int BSS             dword_800BF270; // 0x4 (4) bytes
-int BSS             wave_unload_size_800BF274; // 0x4 (4) bytes
+unsigned long BSS   wave_unload_size_800BF274; // 0x4 (4) bytes
 int BSS             str_mute_off_idx;
 unsigned int BSS    dword_800BF27C; // 0x4 (4) bytes
 int BSS             str_trans_offset; // 4 bytes
 char* BSS           se_header_800BF284; // 0x4 (4) bytes
 int BSS             sd_code_read_800BF288; // 0x4 (4) bytes
-int BSS             se_load_code_800BF28C; // 0x4 (4) bytes
+unsigned long BSS   se_load_code_800BF28C; // 0x4 (4) bytes
 int BSS             sng_kaihi_fg_800BF290; // 0x4 (4) bytes
 int BSS             wave_data_800BF294; // 0x4 (4) bytes
 int BSS             sng_pause_fg_800BF298; // 0x4 (4) bytes
-int BSS             keyoffs_800BF29C; // 0x4 (4) bytes
+unsigned long BSS   keyoffs_800BF29C; // 0x4 (4) bytes
 int BSS             str_read_idx;
 
 gap                                     gap_800BF2A4[0x4]; // 8 bytes
@@ -417,7 +419,7 @@ gap                                     gap_800C042C[0x4]; // 4 bytes
 
 int BSS             sng_fade_time_800C0430[14]; // 0x38 (56) bytes
 char BSS            byte_800C0468[128]; // 0x80 (128) bytes
-unsigned int BSS    song_end_800C04E8; // 0x4 (4) bytes
+unsigned long BSS   song_end_800C04E8; // 0x4 (4) bytes
 int BSS             str_fadein_fg_800C04EC; // 0x4 (4) bytes
 int BSS             str_load_code_800C04F0; // 0x4 (4) bytes
 int BSS             str_fade_time_800C04F4; // 0x4 (4) bytes
@@ -434,9 +436,9 @@ char* BSS           str_trans_buf_800C0514; // 0x4 (4) bytes
 int BSS             sng_fout_term_800C0518; // 0x4 (4) bytes
 int BSS             str_wave_size_800C051C; // 0x4 (4) bytes
 unsigned char *BSS  se_exp_table_800C0520; // 0x4 (4) bytes
-int BSS             keyd_800C0524; // 0x4 (4) bytes
-int BSS             wave_load_code_800C0528; // 0x4 (4) bytes
-int BSS             spu_wave_start_ptr_800C052C; // 0x4 (4) bytes
+unsigned long BSS   keyd_800C0524; // 0x4 (4) bytes
+unsigned long BSS   wave_load_code_800C0528; // 0x4 (4) bytes
+unsigned long BSS   spu_wave_start_ptr_800C052C; // 0x4 (4) bytes
 WAVE_W *BSS         voice_tbl_800C0530; // 0x4 (4) bytes
 
 gap                                     gap_800C0534[0x4]; // 4 bytes
@@ -448,11 +450,11 @@ gap                                     gap_800C0570[0x0]; // 0 bytes
 
 unsigned char *BSS  mptr_800C0570; // 0x4 (4) bytes
 int BSS             se_rev_on_800C0574; // 0x4 (4) bytes
-int BSS             wave_save_code_800C0578; // 0x4 (4) bytes
+unsigned long BSS   wave_save_code_800C0578; // 0x4 (4) bytes
 SOUND_W *BSS        sptr_800C057C; // 0x4 (4) bytes
 int BSS             dword_800C0580; // 0x4 (4) bytes
 unsigned int BSS    str_fade_value_800C0584; // 0x4 (4) bytes
-unsigned char BSS   byte_800C0588[200]; // 0xC8 (200) bytes
+char BSS            spu_malloc_rec_800C0588[200]; // 0xC8 (200) bytes
 int BSS             dword_800C0650; // 0x4 (4) bytes
 int BSS             dword_800C0654; // 0x4 (4) bytes
 SPU_TRACK_REG BSS   spu_tr_wk_800C0658[23]; // 0x564 (1380) bytes
@@ -465,6 +467,9 @@ gap                                     gap_800C0BC4[0x4]; // 4 bytes
 
 int BSS             sng_master_vol_800C0BC8[13]; // 0x34 (52) bytes
 volatile int BSS    sd_task_status_800C0BFC; // 0x4 (4) bytes
+
+/* mts.lib */
+
 mts_msg *BSS        D_800C0C00; // 0x4 (4) bytes
 mts_msg *BSS        D_800C0C04; // 0x4 (4) bytes
 

--- a/src/data/bss.c
+++ b/src/data/bss.c
@@ -298,8 +298,8 @@ gap                                     gap_800BDFC8[0x800]; // 2048 bytes
 
 /* sound.lib */
 
-unsigned long BSS   sd_main_stack_800BE7C8[512]; // 0x800 (2048) bytes
-unsigned long BSS   sd_int_stack_800BEFC8; // 0x4 (4) bytes
+unsigned int BSS    sd_main_stack_800BE7C8[512]; // 0x800 (2048) bytes
+unsigned int BSS    sd_int_stack_800BEFC8; // 0x4 (4) bytes
 int BSS             dword_800BEFCC; // 0x4 (4) bytes
 
 gap                                     gap_800BEFD0[0x4]; // 4 bytes
@@ -325,7 +325,7 @@ int BSS             se_tracks_800BF004; // 0x4 (4) bytes
 gap                                     vrgap2[0x4]; // 4 bytes
 #endif
 int BSS             dword_800BF008; // 0x4 (4) bytes
-unsigned long BSS   blank_data_addr_800BF00C; // 0x4 (4) bytes
+unsigned int BSS    blank_data_addr_800BF00C; // 0x4 (4) bytes
 char* BSS           cdload_buf_800BF010; // 0x4 (4) bytes
 int BSS             se_fp_800BF014; // 0x4 (4) bytes
 int BSS             sd_sng_code_buf_800BF018[16]; // 0x40 (64) bytes
@@ -341,7 +341,7 @@ unsigned long BSS   mdata2_800BF0D4; // 0x4 (4) bytes
 unsigned long BSS   mdata3_800BF0D8; // 0x4 (4) bytes
 unsigned long BSS   mdata4_800BF0DC; // 0x4 (4) bytes
 SEPLAYTBL BSS       se_request_800BF0E0[8]; // 0x60 (96) bytes
-unsigned long BSS   spu_load_offset_800BF140; // 0x4 (4) bytes
+unsigned int BSS    spu_load_offset_800BF140; // 0x4 (4) bytes
 int BSS             vox_rev_on_800BF144; // 0x4 (4) bytes
 
 gap                                     gap_800BF148[0xC]; // 12 bytes
@@ -388,13 +388,13 @@ int BSS             str_off_idx_800BF264; // 0x4 (4) bytes
 int BSS             str_mono_fg_800BF268; // 0x4 (4) bytes
 int BSS             str_fout_fg_800BF26C; // 0x4 (4) bytes
 int BSS             dword_800BF270; // 0x4 (4) bytes
-unsigned long BSS   wave_unload_size_800BF274; // 0x4 (4) bytes
+unsigned int BSS    wave_unload_size_800BF274; // 0x4 (4) bytes
 int BSS             str_mute_off_idx;
 unsigned int BSS    dword_800BF27C; // 0x4 (4) bytes
 int BSS             str_trans_offset; // 4 bytes
 char* BSS           se_header_800BF284; // 0x4 (4) bytes
 int BSS             sd_code_read_800BF288; // 0x4 (4) bytes
-unsigned long BSS   se_load_code_800BF28C; // 0x4 (4) bytes
+unsigned int BSS    se_load_code_800BF28C; // 0x4 (4) bytes
 int BSS             sng_kaihi_fg_800BF290; // 0x4 (4) bytes
 int BSS             wave_data_800BF294; // 0x4 (4) bytes
 int BSS             sng_pause_fg_800BF298; // 0x4 (4) bytes
@@ -419,7 +419,7 @@ gap                                     gap_800C042C[0x4]; // 4 bytes
 
 int BSS             sng_fade_time_800C0430[14]; // 0x38 (56) bytes
 char BSS            byte_800C0468[128]; // 0x80 (128) bytes
-unsigned long BSS   song_end_800C04E8; // 0x4 (4) bytes
+unsigned int BSS    song_end_800C04E8; // 0x4 (4) bytes
 int BSS             str_fadein_fg_800C04EC; // 0x4 (4) bytes
 int BSS             str_load_code_800C04F0; // 0x4 (4) bytes
 int BSS             str_fade_time_800C04F4; // 0x4 (4) bytes
@@ -437,8 +437,8 @@ int BSS             sng_fout_term_800C0518; // 0x4 (4) bytes
 int BSS             str_wave_size_800C051C; // 0x4 (4) bytes
 unsigned char *BSS  se_exp_table_800C0520; // 0x4 (4) bytes
 unsigned long BSS   keyd_800C0524; // 0x4 (4) bytes
-unsigned long BSS   wave_load_code_800C0528; // 0x4 (4) bytes
-unsigned long BSS   spu_wave_start_ptr_800C052C; // 0x4 (4) bytes
+unsigned int BSS    wave_load_code_800C0528; // 0x4 (4) bytes
+unsigned int BSS    spu_wave_start_ptr_800C052C; // 0x4 (4) bytes
 WAVE_W *BSS         voice_tbl_800C0530; // 0x4 (4) bytes
 
 gap                                     gap_800C0534[0x4]; // 4 bytes

--- a/src/data/sbss/sbss.c
+++ b/src/data/sbss/sbss.c
@@ -1,3 +1,5 @@
+#define __BSSDEFINE__
+
 #include "linker.h"
 #include "libgcl/libgcl.h"
 

--- a/src/data/sbss/sbss2.c
+++ b/src/data/sbss/sbss2.c
@@ -1,3 +1,5 @@
+#define __BSSDEFINE__
+
 #include "linker.h"
 #include "Game/control.h"
 

--- a/src/data/sbss/sbss2_2.c
+++ b/src/data/sbss/sbss2_2.c
@@ -1,3 +1,5 @@
+#define __BSSDEFINE__
+
 #include "linker.h"
 #include "Game/game.h"
 

--- a/src/data/sbss/sbss2_3.c
+++ b/src/data/sbss/sbss2_3.c
@@ -1,3 +1,5 @@
+#define __BSSDEFINE__
+
 #include "linker.h"
 #include <sys/types.h>
 #include <libgte.h>

--- a/src/data/sbss/sbss2_4.c
+++ b/src/data/sbss/sbss2_4.c
@@ -1,3 +1,5 @@
+#define __BSSDEFINE__
+
 #include "linker.h"
 #include "Game/game.h"
 

--- a/src/data/sbss/sbss2_5.c
+++ b/src/data/sbss/sbss2_5.c
@@ -1,3 +1,5 @@
+#define __BSSDEFINE__
+
 #include "linker.h"
 
 int SECTION(".sbss") GM_PadVibration2_800ABA54;

--- a/src/data/sbss/sbss3.c
+++ b/src/data/sbss/sbss3.c
@@ -1,3 +1,5 @@
+#define __BSSDEFINE__
+
 #include "linker.h"
 #include "Menu/menuman.h"
 #include "Game/map.h"

--- a/src/data/sbss/sbss4.c
+++ b/src/data/sbss/sbss4.c
@@ -1,3 +1,5 @@
+#define __BSSDEFINE__
+
 #include "linker.h"
 #include "libdg/libdg.h"
 

--- a/src/data/sbss/sbss5.c
+++ b/src/data/sbss/sbss5.c
@@ -1,3 +1,5 @@
+#define __BSSDEFINE__
+
 #include "linker.h"
 #include "chara/snake/sna_init.h"
 #include "Menu/radio.h"

--- a/src/data/sbss/sbss6.c
+++ b/src/data/sbss/sbss6.c
@@ -1,3 +1,5 @@
+#define __BSSDEFINE__
+
 #include "linker.h"
 #include <sys/types.h>
 #include <libgte.h>

--- a/src/libdg/pshade.c
+++ b/src/libdg/pshade.c
@@ -10,18 +10,20 @@ extern CVECTOR      DG_PacketCode_800AB394[2];
 extern DG_LitVertex DG_LitVertices_800B7A50[84];
 
 //there are a few of these that are close to gte_MulMatrix0 but with the first part changed
-#define gte_Unknown(r1, r2)                                                                                            \
-    {                                                                                                                  \
-        gte_ldclmv(r1);                                                                                                \
-        gte_rtir();                                                                                                    \
-        gte_stclmv(r2);                                                                                                \
-        gte_ldclmv((char *)r1 + 2);                                                                                    \
-        gte_rtir();                                                                                                    \
-        gte_stclmv((char *)r2 + 2);                                                                                    \
-        gte_ldclmv((char *)r1 + 4);                                                                                    \
-        gte_rtir();                                                                                                    \
-        gte_stclmv((char *)r2 + 4);                                                                                    \
+// clang-format off
+#define gte_Unknown(r1, r2)                                     \
+    {                                                           \
+        gte_ldclmv(r1);                                         \
+        gte_rtir();                                             \
+        gte_stclmv(r2);                                         \
+        gte_ldclmv((char *)r1 + 2);                             \
+        gte_rtir();                                             \
+        gte_stclmv((char *)r2 + 2);                             \
+        gte_ldclmv((char *)r1 + 4);                             \
+        gte_rtir();                                             \
+        gte_stclmv((char *)r2 + 4);                             \
     }
+// clang-format on
 
 void Prim_lighting_80031954(SVECTOR *pVerts, int numVerts, DG_LitVertex *pOut, DG_LIT *pLights, int numLights)
 {

--- a/src/libdg/screen.c
+++ b/src/libdg/screen.c
@@ -7,21 +7,23 @@ extern DG_CHNL DG_Chanls_800B1800[3];
 
 extern MATRIX DG_ZeroMatrix_8009D430;
 
-#define gte_MulMatrix02(r1, r2, r3)                                                                                    \
-    {                                                                                                                  \
-        gte_ldlv0(r1);                                                                                                 \
-        gte_rt();                                                                                                      \
-        gte_stlvnl(r1);                                                                                                \
-        gte_ldclmv(r2);                                                                                                \
-        gte_rtir();                                                                                                    \
-        gte_stclmv(r3);                                                                                                \
-        gte_ldclmv((char *)r2 + 2);                                                                                    \
-        gte_rtir();                                                                                                    \
-        gte_stclmv((char *)r3 + 2);                                                                                    \
-        gte_ldclmv((char *)r2 + 4);                                                                                    \
-        gte_rtir();                                                                                                    \
-        gte_stclmv((char *)r3 + 4);                                                                                    \
+// clang-format off
+#define gte_MulMatrix02(r1, r2, r3)                             \
+    {                                                           \
+        gte_ldlv0(r1);                                          \
+        gte_rt();                                               \
+        gte_stlvnl(r1);                                         \
+        gte_ldclmv(r2);                                         \
+        gte_rtir();                                             \
+        gte_stclmv(r3);                                         \
+        gte_ldclmv((char *)r2 + 2);                             \
+        gte_rtir();                                             \
+        gte_stclmv((char *)r3 + 2);                             \
+        gte_ldclmv((char *)r2 + 4);                             \
+        gte_rtir();                                             \
+        gte_stclmv((char *)r3 + 4);                             \
     }
+// clang-format on
 
 void DG_SetPos_8001BC44(MATRIX *matrix)
 {

--- a/src/libdg/shade.c
+++ b/src/libdg/shade.c
@@ -9,18 +9,20 @@ extern SVECTOR DG_Ambient_800AB38C;
 /*************************************/
 
 //there are a few of these that are close to  gte_MulMatrix0 but with the first part changed
-#define gte_Unknown(r1, r2)                                                                                            \
-    {                                                                                                                  \
-        gte_ldclmv(r1);                                                                                                \
-        gte_rtir();                                                                                                    \
-        gte_stclmv(r2);                                                                                                \
-        gte_ldclmv((char *)r1 + 2);                                                                                    \
-        gte_rtir();                                                                                                    \
-        gte_stclmv((char *)r2 + 2);                                                                                    \
-        gte_ldclmv((char *)r1 + 4);                                                                                    \
-        gte_rtir();                                                                                                    \
-        gte_stclmv((char *)r2 + 4);                                                                                    \
+// clang-format off
+#define gte_Unknown(r1, r2)                                     \
+    {                                                           \
+        gte_ldclmv(r1);                                         \
+        gte_rtir();                                             \
+        gte_stclmv(r2);                                         \
+        gte_ldclmv((char *)r1 + 2);                             \
+        gte_rtir();                                             \
+        gte_stclmv((char *)r2 + 2);                             \
+        gte_ldclmv((char *)r1 + 4);                             \
+        gte_rtir();                                             \
+        gte_stclmv((char *)r2 + 4);                             \
     }
+// clang-format on
 
 void DG_ShadeStart_8001CF80()
 {

--- a/src/overlays/camera/Unknown/camera.c
+++ b/src/overlays/camera/Unknown/camera.c
@@ -380,7 +380,7 @@ void camera_800C5D2C(SPRT *pPrim) // duplicate of set_sprt_default_8004AE14
 // but with GV_AllocMemory_80015EB8(2, ...)
 // instead of GV_AllocMemory_80015EB8(0, ...)
 // and with one font_set_color_80044DC4 missing
-void camera_800C5D54(Actor_MenuMan *work)
+void camera_800C5D54(MenuWork *work)
 {
     KCB  local_kcb;
     KCB *allocated_kcb;
@@ -410,12 +410,13 @@ void camera_800C5D54(Actor_MenuMan *work)
     }
 }
 
-void camera_800C5EB4(Actor_MenuMan *param_1, const char *str) // duplicate of menu_radio_do_file_mode_helper7_8004AE3C
+// duplicate of menu_radio_do_file_mode_helper7_8004AE3C
+void camera_800C5EB4(MenuWork *work, const char *str)
 {
     int  height;
     KCB *kcb;
 
-    kcb = param_1->field_214_font;
+    kcb = work->field_214_font;
 
     height = kcb->height_info;
     kcb->height_info = 14;
@@ -426,7 +427,8 @@ void camera_800C5EB4(Actor_MenuMan *param_1, const char *str) // duplicate of me
     font_update_8004695C(kcb);
 }
 
-void camera_800C5F20(SELECT_INFO *info) // duplicate of sub_8004AEA8
+// duplicate of sub_8004AEA8
+void camera_800C5F20(SELECT_INFO *info)
 {
     int   top;
     int   i, y;
@@ -469,8 +471,9 @@ void camera_800C5F20(SELECT_INFO *info) // duplicate of sub_8004AEA8
     font_update_8004695C(kcb);
 }
 
-void camera_800C6054(Actor_MenuMan *work, char *pOt,
-                     SELECT_INFO *info) // duplicate of menu_radio_do_file_mode_helper8_8004AFE4
+// duplicate of menu_radio_do_file_mode_helper8_8004AFE4
+void camera_800C6054(MenuWork *work, char *pOt,
+                     SELECT_INFO *info)
 {
     unsigned int xoff;
     SPRT        *pPrim;
@@ -564,8 +567,8 @@ void camera_800C6984(SELECT_INFO *info, int param_2)
 }
 
 // duplicate of menu_radio_do_file_mode_helper12_8004BA80
-int camera_800C6A40(Actor_MenuMan *work, mem_card *pMemcard, const char *param_3,
-                                              SELECT_INFO *info)
+int camera_800C6A40(MenuWork *work, mem_card *pMemcard, const char *param_3,
+                    SELECT_INFO *info)
 {
     MENU_CURPOS *pIter;
     mem_card_block      *pBlock;
@@ -648,7 +651,7 @@ extern int camera_dword_800C3430;
 extern const int camera_aNocard_800D003C[];
 
 // duplicate of menu_radio_do_file_mode_helper14_8004BE98
-void camera_800C6E78(Actor_MenuMan *work, char *param_2, SELECT_INFO *info)
+void camera_800C6E78(MenuWork *work, char *param_2, SELECT_INFO *info)
 {
     MENU_CURPOS *infoChild;
     int                  idx, idx_copy;
@@ -711,8 +714,8 @@ void camera_800C6E78(Actor_MenuMan *work, char *param_2, SELECT_INFO *info)
 }
 
 // duplicate of menu_radio_do_file_mode_helper15_8004C04C, but with one missing line
-void camera_800C703C(Actor_MenuMan *work, const char **srcs, int cnt, int field_4, const char *field_20,
-                                               SELECT_INFO *info)
+void camera_800C703C(MenuWork *work, const char **srcs, int cnt, int field_4, const char *field_20,
+                     SELECT_INFO *info)
 {
     KCB                 *kcb;
     const char          *src;

--- a/src/overlays/s15b/Okajima/splash3.c
+++ b/src/overlays/s15b/Okajima/splash3.c
@@ -173,9 +173,8 @@ static inline void Splash3InitPack(POLY_FT4 *pack, DG_TEX *tex)
     setRGB0(pack, 255, 255, 255);
 }
 
-#define Splash3Init                                                      \
-do                                                                       \
-{                                                                        \
+#define Splash3Init()                                                    \
+do {                                                                     \
     SVECTOR   rot;                                                       \
     VECTOR    scale;                                                     \
     POLY_FT4 *packs0;                                                    \
@@ -242,7 +241,7 @@ int Splash3GetResources_800C810C(Splash3Work *work, int dir, SVECTOR *pos)
         return -1;
     }
 
-    Splash3Init; // Not sure why this is needed
+    Splash3Init(); // Not sure why this is needed
 }
 
 GV_ACT * NewSplash3_800C83D0(int dir, SVECTOR *pos)

--- a/src/overlays/select/Takabe/vib_edit.c
+++ b/src/overlays/select/Takabe/vib_edit.c
@@ -30,7 +30,7 @@ typedef struct _VibEditWork
     int            field_3C;
     int            field_40;
     VibEditPrims  *field_44_prims;
-    Actor_Vibrate *field_48_vibrate;
+    VibrateWork   *field_48_vibrate;
     VibPair        field_4C_pairs[16];
     int            field_6C;
     VibPair        field_70_pairs[16];


### PR DESCRIPTION
- Renamed a few things besides MenuWork in ``Menu/`` to match with memleaks.
- Added a friendlier aliases for most SEs in g_sound.h so the game code doesn't have to use the SE data's internal names. If this is overkill you can just remove the internal name defines and assign the constants directly or whatever. Anyway, there's still a few I couldn't figure out.
- SD cleanup is still a bit rough, maybe shouldn't be merged until I sort out some of the type conflicts. ¯\_(ツ)_/¯
- I think it's a better approach to simply hide extern BSS declarations from bss.c & friends than endlessly copy-paste declarations into each source file. I got bitten by this when splitting SD not just because it was tedious but also because of inconsistent types between declarations (and prototypes).