### PR TITLE
Menu cleanups

### DIFF
--- a/source/menu/item.c
+++ b/source/menu/item.c
@@ -332,11 +332,11 @@ int menu_item_IsItemDisabled_8003B6D0(int item)
 
 void menu_drawPalKey_8003B794(MenuWork *work, unsigned int *pOt, int id)
 {
-    RECT           pal_rect;
-    RECT           img_rect;
-    Menu_rpk_item *pPalItem;
-    Menu_rpk_item *pImgItem;
-    SPRT          *pSprt;
+    RECT      pal_rect;
+    RECT      img_rect;
+    RPK_ITEM *pPalItem;
+    RPK_ITEM *pImgItem;
+    SPRT     *pSprt;
 
     pPalItem = menu_rpk_get_pal_8003DD9C(id * 2 + 33);
     pImgItem = menu_rpk_get_img_8003DDB4(id * 2 + 34);
@@ -345,13 +345,13 @@ void menu_drawPalKey_8003B794(MenuWork *work, unsigned int *pOt, int id)
     pal_rect.y = 336;
     pal_rect.w = 16;
     pal_rect.h = 1;
-    LoadImage(&pal_rect, pPalItem->field_4_pixel_ptr);
+    LoadImage(&pal_rect, pPalItem->data);
 
     img_rect.x = 960;
     img_rect.y = 337;
-    img_rect.w = pImgItem->field_2_w;
-    img_rect.h = pImgItem->field_3_h;
-    LoadImage(&img_rect, pImgItem->field_4_pixel_ptr);
+    img_rect.w = pImgItem->w;
+    img_rect.h = pImgItem->h;
+    LoadImage(&img_rect, pImgItem->data);
 
     NEW_PRIM(pSprt, work);
 
@@ -359,8 +359,8 @@ void menu_drawPalKey_8003B794(MenuWork *work, unsigned int *pOt, int id)
     pSprt->x0 = 230;
     pSprt->u0 = 0;
     pSprt->y0 = 116;
-    pSprt->w = pImgItem->field_2_w * 4;
-    pSprt->h = pImgItem->field_3_h;
+    pSprt->w = pImgItem->w * 4;
+    pSprt->h = pImgItem->h;
     LSTORE(0x80808080, &pSprt->r0);
     pSprt->clut = getClut(pal_rect.x, pal_rect.y);
     setSprt(pSprt);

--- a/source/menu/life.c
+++ b/source/menu/life.c
@@ -121,7 +121,7 @@ void menu_draw_bar(MenuPrim *prim, long x, long y, long rest, long now, long max
 
     if ( !((int)bconf & 0x80000000) )
     {
-        // Blue color of the O2 bar text
+        // Red flashing text when taking smoking or O2 damage
         text_config.colour = 0x643030FF;
     }
     else

--- a/source/menu/menuman.h
+++ b/source/menu/menuman.h
@@ -234,26 +234,23 @@ typedef struct MenuPrim
     unsigned char *mPrimPtrs[2];
 } MenuPrim;
 
-typedef struct _Menu_rpk_item
+typedef struct RPK_ITEM
 {
-    char   field_0_x;
-    char   field_1_y;
-    char   field_2_w;
-    char   field_3_h;
-    u_long field_4_pixel_ptr[0];
-} Menu_rpk_item;
+    char   x, y, w, h;
+    u_long data[0];
+} RPK_ITEM;
 
 // This struct describes the structure of
 // ".rpk" files (".rpk", 'r', 0x72). Note
 // that 'r' (0x72) can be either a ".rar",
 // ".res" or ".rpk" file.
-typedef struct
+typedef struct RPK // resource pack?
 {
-    unsigned char  field_0_count1;
-    unsigned char  field_1_count2;
-    short          pad;
-    Menu_rpk_item *items[0]; // pointers ??
-} RpkHeader;
+    u_char    palettes;
+    u_char    images;
+    short     pad;
+    RPK_ITEM *items[0];
+} RPK;
 
 typedef struct _MENU_BAR_CONF
 {
@@ -398,26 +395,25 @@ typedef struct Menu_Triangle
 } Menu_Triangle;
 
 PANEL_TEXTURE *menu_weapon_get_weapon_rpk_info_8003DED8(int weaponIdx);
-Menu_rpk_item            **menu_rpk_init_8003DD1C(const char *pFileName);
-void                       menu_restore_nouse(void);
+RPK_ITEM     **menu_rpk_init_8003DD1C(const char *pFileName);
+void           menu_restore_nouse(void);
 PANEL_TEXTURE *menu_rpk_8003B5E0(int idx);
-void         sub_8003CB98(struct MenuWork *a1);
-int          menu_radio_do_file_mode(MenuWork *work, GV_PAD *pPad);
-void         sub_8003CFE0(PANEL_TEXTURE *images, int index);
-void         draw_life_defaultX_8003F408(MenuPrim *prim, long y, long rest, long now, long max, MENU_BAR_CONF *bconf);
-void         draw_life_8003F464(MenuPrim *prim, long x, long y, long rest, long now, long max, MENU_BAR_CONF *bconf);
-void         menu_draw_bar(MenuPrim *prim, long x, long y, long rest, long now, long max, MENU_BAR_CONF *bconf);
-void         MENU_InitRadioTable(void);
-// void         set_sprt_default_8004AE14(SPRT *pSprt);
-void         move_coord(int *arr, int len);
-void         MENU_ResetSystem(void);
-void         MENU_SetRadarScale(int);
-void         MENU_StartDeamon(void);
-void         menu_Text_Init_80038B98(void);
-void         menu_Text_PrimUnknown_80038BB4(void);
-void         menu_init_nouse(void);
-void         menu_init_rpk_item_8003DDCC(PANEL_TEXTURE *pUnk, int imgIdx, int palIdx);
-int          menu_draw_num(int number);
+void           sub_8003CB98(struct MenuWork *a1);
+int            menu_radio_do_file_mode(MenuWork *work, GV_PAD *pPad);
+void           sub_8003CFE0(PANEL_TEXTURE *images, int index);
+void           draw_life_defaultX_8003F408(MenuPrim *prim, long y, long rest, long now, long max, MENU_BAR_CONF *bconf);
+void           draw_life_8003F464(MenuPrim *prim, long x, long y, long rest, long now, long max, MENU_BAR_CONF *bconf);
+void           menu_draw_bar(MenuPrim *prim, long x, long y, long rest, long now, long max, MENU_BAR_CONF *bconf);
+void           MENU_InitRadioTable(void);
+void           move_coord(int *arr, int len);
+void           MENU_ResetSystem(void);
+void           MENU_SetRadarScale(int);
+void           MENU_StartDeamon(void);
+void           menu_Text_Init_80038B98(void);
+void           menu_Text_PrimUnknown_80038BB4(void);
+void           menu_init_nouse(void);
+void           menu_init_rpk_item_8003DDCC(PANEL_TEXTURE *pUnk, int imgIdx, int palIdx);
+int            menu_draw_num(int number);
 
 void menu_radio_draw_face_helper_800470F4(int idx);
 void menu_radio_draw_face_helper2_800486F4(menu_chara_struct_sub *pSub, int idx);
@@ -475,8 +471,8 @@ void MENU_SetRadioOverCall(int contactFrequency, int radioTableCode);
 void MENU_InitRadioMemory(void);
 void menu_radio_update_helper_80038A6C(void);
 TILE          *menu_render_rect_8003DB2C(MenuPrim *pOt, int x, int y, int w, int h, int rgb);
-Menu_rpk_item *menu_rpk_get_img_8003DDB4(int id);
-Menu_rpk_item *menu_rpk_get_pal_8003DD9C(int id);
+RPK_ITEM      *menu_rpk_get_img_8003DDB4(int id);
+RPK_ITEM      *menu_rpk_get_pal_8003DD9C(int id);
 void           MENU_JimakuClear(void);
 void           MENU_Locate(int xpos, int ypos, int flags);
 void           MENU_Color(int r, int g, int b);

--- a/source/menu/radar.c
+++ b/source/menu/radar.c
@@ -24,8 +24,8 @@ STATIC short inactive7segmentColors_800AB4A8[4] = {0x8023, 0x8023, 0x8023, 0x000
 STATIC int cons_current_y_800AB4B0 = 0;
 STATIC int cons_current_x_800AB4B4 = 0;
 
-Menu_rpk_item *SECTION(".sbss") gRadar_rpk_800ABAC8;
-int            SECTION(".sbss") dword_800ABACC;
+RPK_ITEM *SECTION(".sbss") gRadar_rpk_800ABAC8;
+int       SECTION(".sbss") dword_800ABACC;
 
 extern short    image_8009E338[];
 extern char     gDigit7Segment_8009E60C[];
@@ -1020,8 +1020,8 @@ void menu_radar_load_rpk_8003AD64()
 
     rect.x = 992;
     rect.y = 336;
-    rect.w = gRadar_rpk_800ABAC8->field_2_w;
-    rect.h = gRadar_rpk_800ABAC8->field_3_h;
+    rect.w = gRadar_rpk_800ABAC8->w;
+    rect.h = gRadar_rpk_800ABAC8->h;
     LoadImage(&rect, (u_long *)&gRadar_rpk_800ABAC8[1]);
 }
 

--- a/source/menu/radio.c
+++ b/source/menu/radio.c
@@ -390,31 +390,29 @@ void menu_radio_codec_helper_helper14_helper5_800402A0(MenuPrim *pGlue, int xoff
 
 void menu_RadioCall_helper_800403E4(void)
 {
-    int        id;
-    ResHeader *pRes;
-    RECT       clut_rect;
-    char      *buf;
-    RECT      *pRect;
+    TIM  *tim;
+    RECT  clut_rect;
+    char *pixel_data;
+    RECT *pixel_rect;
 
-    id = GV_CacheID2("call", 'r');
-    pRes = GV_GetCache(id);
+    tim = GV_GetCache(GV_CacheID2("call", 'r'));
 
     clut_rect.x = 960;
     clut_rect.y = 371;
     clut_rect.w = 16;
     clut_rect.h = 1;
 
-    LoadImage(&clut_rect, (u_long *)pRes->field_14);
+    LoadImage(&clut_rect, (u_long *)tim->clut_data);
 
-    buf = (char *)&pRes->field_14[pRes->field_8 >> 1];
-    pRect = (RECT *)(buf - 8);
+    pixel_data = (char *)&tim->clut_data[tim->clut.bnum >> 1];
+    pixel_rect = (RECT *)(pixel_data - 8);
 
     gRadioClut_800ABAFC = getClut(clut_rect.x, clut_rect.y);
 
-    pRect->x = 960;
-    pRect->y = 372;
+    pixel_rect->x = 960;
+    pixel_rect->y = 372;
 
-    LoadImage(pRect, (u_long *)buf);
+    LoadImage(pixel_rect, (u_long *)pixel_data);
 }
 
 void menu_radio_update_helper3_80040498(MenuPrim *pGlue)
@@ -1729,46 +1727,49 @@ extern SPRT gRadioNumberSprt2_800bd9d0;
 
 void menu_number_init(MenuWork *work)
 {
-    RECT       rect1, rect2;
-    ResHeader *pRes;
-    SPRT      *pSprt;
+    RECT  texture_rect;
+    RECT  clut_rect;
+    TIM  *tim;
+    SPRT *sprt;
 
-    rect1 = rect_800AB64C[0];
+    texture_rect = rect_800AB64C[0];
 
     // Loads "num.res" (c70e.r) file:
-    pRes = GV_GetCache(GV_CacheID2("num", 'r'));
+    tim = GV_GetCache(GV_CacheID2("num", 'r'));
 
-    pRes->field_14[0] = 0; // TODO: Why zero out the first pixel of image?
+    // The first CLUT entry must be transparent
+    tim->clut_data[0] = 0;
 
-    rect2.x = 960;
-    rect2.y = 511;
-    rect2.w = 16;
-    rect2.h = 1;
+    clut_rect.x = 960;
+    clut_rect.y = 511;
+    clut_rect.w = 16;
+    clut_rect.h = 1;
 
-    LoadImage(&rect2, (u_long *)pRes->field_14);
-    LoadImage(&rect1, (u_long *)&pRes->field_14[pRes->field_8 >> 1]);
+    LoadImage(&clut_rect, (u_long *)tim->clut_data);
+    LoadImage(&texture_rect, (u_long *)&tim->clut_data[tim->clut.bnum >> 1]);
 
-    pSprt = &gRadioNumberSprt_800bd9b0;
-    setSprt(pSprt);
-    pSprt->r0 = 128;
-    pSprt->g0 = 128;
-    pSprt->b0 = 128;
-    pSprt->u0 = 0x9c;
-    pSprt->v0 = 0xe8;
-    pSprt->w = 6;
-    pSprt->h = 7;
-    pSprt->clut = 0x7ffc;
+    sprt = &gRadioNumberSprt_800bd9b0;
+    setSprt(sprt);
+    sprt->r0 = 128;
+    sprt->g0 = 128;
+    sprt->b0 = 128;
+    sprt->u0 = 0x9c;
+    sprt->v0 = 0xe8;
+    sprt->w = 6;
+    sprt->h = 7;
+    sprt->clut = 0x7ffc;
 
-    pSprt = &gRadioNumberSprt2_800bd9d0;
-    setSprt(pSprt);
-    pSprt->r0 = 128;
-    pSprt->g0 = 128;
-    pSprt->b0 = 128;
-    pSprt->u0 = 0;
-    pSprt->v0 = 0xed;
-    pSprt->w = 6;
-    pSprt->h = 5;
-    pSprt->clut = 0x7ffc;
+    sprt = &gRadioNumberSprt2_800bd9d0;
+    setSprt(sprt);
+    sprt->r0 = 128;
+    sprt->g0 = 128;
+    sprt->b0 = 128;
+    sprt->u0 = 0;
+    sprt->v0 = 0xed;
+    sprt->w = 6;
+    sprt->h = 5;
+    sprt->clut = 0x7ffc;
+
     menu_set_string2();
 }
 

--- a/source/menu/radio.h
+++ b/source/menu/radio.h
@@ -167,22 +167,21 @@ typedef struct Radio_8009E664
 // and it is not described by those structs.
 //
 // TODO: Is radio.h the right header file for this?
-typedef struct ResHeader_Sub
+typedef struct TIM_DATA
 {
-    int  field_0;
-    RECT field_4;
-} ResHeader_Sub;
+    u_int   bnum;
+    RECT    rect;
+    u_short data[0];
+} TIM_DATA;
 
-typedef struct ResHeader
+typedef struct TIM
 {
-    int           field_0;
-    int           field_4;
-    unsigned int  field_8;
-    int           field_C;
-    int           field_10;
-    short         field_14[16];
-    ResHeader_Sub field_34;
-} ResHeader;
+    int      id;
+    int      flag;
+    TIM_DATA clut;
+    u_short  clut_data[16];
+    TIM_DATA pixel;
+} TIM;
 
 void           sub_8004D580(int pressed);
 void           sub_8004124C(MenuWork *work);


### PR DESCRIPTION
Rename ResHeader as TIM, this is just a standard PlayStation TIM,
but there are no definitions provided for it in the SDK.

Rename RpkHeader to RPK.