### PR TITLE
 Unsuffix work & next batch of changes (Vol.10)

### DIFF
--- a/source/bullet/jirai.c
+++ b/source/bullet/jirai.c
@@ -116,7 +116,7 @@ static void JiraiDisplayText(JiraiWork *work, int arg1)
     int r, g, b;
     const char *text;
 
-    matrix = &DG_Chanl(0)->field_10_eye_inv;
+    matrix = &DG_Chanl(0)->eye_inv;
 
     gte_SetRotMatrix(matrix);
     gte_SetTransMatrix(matrix);

--- a/source/chara/snake/sna_init.c
+++ b/source/chara/snake/sna_init.c
@@ -7926,7 +7926,7 @@ void sna_init_main_logic_800596FC(SnaInitWork *work)
 
     if ( work->field_9A0 != 0 )
     {
-        addPrim(DG_Chanl(1)->mOrderingTables[GV_Clock], &work->field_950[GV_Clock]);
+        addPrim(DG_Chanl(1)->ot[GV_Clock], &work->field_950[GV_Clock]);
         work->field_9A0--;
     }
 

--- a/source/chara/snake_vr/sna_init.c
+++ b/source/chara/snake_vr/sna_init.c
@@ -7542,7 +7542,7 @@ void sna_init_main_logic_800596FC(SnaInitWork *work)
 
     if ( work->field_9A0 != 0 )
     {
-        addPrim(DG_Chanl(1)->mOrderingTables[GV_Clock], &work->field_950[GV_Clock]);
+        addPrim(DG_Chanl(1)->ot[GV_Clock], &work->field_950[GV_Clock]);
         work->field_9A0--;
     }
 

--- a/source/data/bss.c
+++ b/source/data/bss.c
@@ -226,7 +226,7 @@ UnkCameraStruct2 BSS gUnkCameraStruct2_800B7868; // 0x24 (36) bytes
 gap                                     gap_800B788C[0x4]; // 4 bytes
 
 /* game/map.obj */
-DG_OBJS *BSS        StageObjs_800B7890[32]; // 0x80 (128) bytes
+DG_OBJS *BSS        StageObjs[32]; // 0x80 (128) bytes
 MAP BSS      gMapRecs_800B7910[16]; // 0x140 (320) bytes
 
 /* libdg/pshade.obj */

--- a/source/data/bss.c
+++ b/source/data/bss.c
@@ -77,7 +77,7 @@ int BSS             dword_800B05A8[6]; // 0x18 (24) bytes
 GV_PAD BSS          GV_PadData[4]; // 0x40 (64) bytes
 
 /* libdg/display.c */
-DISPENV BSS         gDispEnv_800B0600; // 0x14 (20) bytes
+DISPENV BSS         g_dispenv; // 0x14 (20) bytes
 
 gap                                     gap_800B0614[0xC]; // 12 bytes
 

--- a/source/data/bss.c
+++ b/source/data/bss.c
@@ -91,7 +91,7 @@ DG_OBJS *BSS        dword_800B0F60[8]; // 0x20 (32) bytes
 DG_OBJS *BSS        dword_800B0F80[256]; // 0x400 (1024) bytes
 DR_ENV BSS          stru_800B1380[2]; // 0x80 (128) bytes
 unsigned int *BSS   ptr_800B1400[256]; // 0x400 (1024) bytes
-DG_CHANL BSS        DG_Chanls_800B1800[3]; // 0x5C4 (1476) bytes
+DG_CHANL BSS        DG_Chanls[3]; // 0x5C4 (1476) bytes
 
 gap                                     gap_800B1DC4[0x4]; // 4 bytes
 
@@ -115,7 +115,7 @@ gap                                     gap_800B3794[0x4]; // 4 bytes
 unsigned char BSS   pcxBuffer_800B3798[128]; // 0x80 (128) bytes
 
 /* libdg/palette.obj (?) */
-u_long BSS          DG_PaletteBuffer_800B3818[256]; // 0x400 (1024) bytes
+u_long BSS          DG_PaletteBuffer[256]; // 0x400 (1024) bytes
 
 /* libgcl/command.obj */
 GCL_SCRIPT BSS      current_script; // 0xC (12) bytes

--- a/source/equip/gglsight.c
+++ b/source/equip/gglsight.c
@@ -196,7 +196,7 @@ static void DrawHudBarGraph(Work *work)
     poly = work->field_2E0_polyF4[GV_Clock];
     tpage = &work->field_370_dr_tpage[GV_Clock];
 
-    ot = (u_long *)DG_Chanl(1)->mOrderingTables[GV_Clock];
+    ot = (u_long *)DG_Chanl(1)->ot[GV_Clock];
 
     y = GM_PlayerControl->rot.vy & 4095;
     y2 = ((y + 1024) & 2047) >> 5;

--- a/source/equip/scope.c
+++ b/source/equip/scope.c
@@ -124,12 +124,12 @@ static void SetSideLinesPairPosition(LINE_F2 *lines, int x, int y)
     lines->x1 = x;
     lines->x0 = x;
     offsetIndex = 4;
-    lines[offsetIndex].x1 = 320 - x;
-    lines[offsetIndex].x0 = 320 - x;
+    lines[offsetIndex].x1 = SCREEN_WIDTH - x;
+    lines[offsetIndex].x0 = SCREEN_WIDTH - x;
     lines[offsetIndex].y0 = y;
     lines->y0 = y;
-    lines[offsetIndex].y1 = 240 - y; // Bottom y.
-    lines->y1 = 240 - y;
+    lines[offsetIndex].y1 = SCREEN_HEIGHT - y; // Bottom y.
+    lines->y1 = SCREEN_HEIGHT - y;
 }
 
 static void DrawSideLines(LINE_F2 *lines, int param_2)

--- a/source/equip/scope.c
+++ b/source/equip/scope.c
@@ -88,7 +88,7 @@ static int GetZoomLimit(Work *work)
 
     if ( GM_GameStatus < 0 )
     {
-        eye = &DG_Chanl(0)->field_30_eye;
+        eye = &DG_Chanl(0)->eye;
     }
     else
     {
@@ -517,9 +517,9 @@ static void DrawMovingBarGraph(Work *work, u_long *ot)
     int      numOTEntries;
 
     pLine_F3 = work->bar_graph[GV_Clock];
-    chnlOt = DG_Chanl(0)->mOrderingTables[1 - GV_Clock];
+    chnlOt = DG_Chanl(0)->ot[1 - GV_Clock];
 
-    numOTEntries = DG_Chanl(0)->word_6BC374_8 - 4;
+    numOTEntries = DG_Chanl(0)->field_08 - 4;
     for (i = 0; i < 16; i++)
     {
         otMin = chnlOt + ((i << numOTEntries) * 4);

--- a/source/game/chara.c
+++ b/source/game/chara.c
@@ -44,9 +44,10 @@ NEWCHARA GM_GetChara(unsigned char *script)
 NEWCHARA GM_GetCharaID(int chara_id)
 {
     CHARA *chara_table;
-    int    i = 0;
+    int    i;
 
-    do {
+    for (i = 0; i < 2; i++)
+    {
         // First search the fixed set of commands
         chara_table = &MainCharacterEntries[0];
         if (i != 0)
@@ -55,18 +56,14 @@ NEWCHARA GM_GetCharaID(int chara_id)
             chara_table = (CHARA *)StageCharacterEntries;
         }
 
-        if (chara_table->func)
+        for (; chara_table->func != NULL; chara_table++)
         {
-            do {
-                if (chara_table->class_id == chara_id)
-                {
-                    return chara_table->func;
-                }
-                chara_table++;
-            } while (chara_table->func);
+            if (chara_table->class_id == chara_id)
+            {
+                return chara_table->func;
+            }
         }
-        i++;
-    } while (i < 2);
+    }
 
     return NULL;
 }

--- a/source/game/item.c
+++ b/source/game/item.c
@@ -275,8 +275,8 @@ STATIC int item_act_helper_80033704(short *pOut, SVECTOR *pIn)
 {
     long z;
 
-    gte_SetRotMatrix(&DG_Chanl(0)->field_10_eye_inv);
-    gte_SetTransMatrix(&DG_Chanl(0)->field_10_eye_inv);
+    gte_SetRotMatrix(&DG_Chanl(0)->eye_inv);
+    gte_SetTransMatrix(&DG_Chanl(0)->eye_inv);
 
     gte_ldv0(pIn);
     gte_rtps();

--- a/source/game/item.c
+++ b/source/game/item.c
@@ -571,9 +571,9 @@ STATIC void item_Act(ItemWork *work)
         newy = 32;
     }
 
-    if (newy > 224)
+    if (newy > FRAME_HEIGHT)
     {
-        newy = 224;
+        newy = FRAME_HEIGHT;
     }
 
     pLine->x0 = newx;

--- a/source/game/map.c
+++ b/source/game/map.c
@@ -9,11 +9,11 @@
 #include "game.h"
 
 extern MAP      gMapRecs_800B7910[ 16 ];
-extern DG_OBJS *StageObjs_800B7890[ 32 ];
+extern DG_OBJS *StageObjs[ 32 ];
 extern int      DG_CurrentGroupID;
 
 STATIC MAP* SECTION(".sbss") pHzdIter_800ABAA0;
-STATIC int  SECTION(".sbss") N_StageObjs_800ABAA4;
+STATIC int  SECTION(".sbss") N_StageObjs;
 STATIC int  SECTION(".sbss") gMapCount_800ABAA8;
 STATIC int  SECTION(".sbss") gMapsChanged_800ABAAC;
 
@@ -39,10 +39,10 @@ STATIC void GM_UpdateMapGroup( int preshade )
             continue;
         }
 
-        objs = StageObjs_800B7890;
+        objs = StageObjs;
         group |= map->index;
 
-        for ( j = N_StageObjs_800ABAA4; j > 0; j-- )
+        for ( j = N_StageObjs; j > 0; j-- )
         {
             if ( map->index & objs[ 0 ]->group_id )
             {
@@ -124,8 +124,8 @@ STATIC void GM_LoadMapModel(int name, MAP *map)
     DG_QueueObjs(objs);
     DG_GroupObjs(objs, map->index);
 
-    StageObjs_800B7890[N_StageObjs_800ABAA4] = objs;
-    N_StageObjs_800ABAA4++;
+    StageObjs[N_StageObjs] = objs;
+    N_StageObjs++;
 }
 
 STATIC HZD_HDL *GM_LoadHazard(int name, int area, int index, int dyn_walls, int dyn_floors)
@@ -169,8 +169,8 @@ void GM_ResetMapModel(void)
     DG_OBJS **objs;
     int       i;
 
-    objs = StageObjs_800B7890;
-    for (i = N_StageObjs_800ABAA4; i > 0; i--)
+    objs = StageObjs;
+    for (i = N_StageObjs; i > 0; i--)
     {
         if (*objs)
         {
@@ -182,7 +182,7 @@ void GM_ResetMapModel(void)
         *objs++ = NULL;
     }
 
-    N_StageObjs_800ABAA4 = 0;
+    N_StageObjs = 0;
 }
 
 void GM_ResetMap(void)
@@ -190,13 +190,13 @@ void GM_ResetMap(void)
     DG_OBJS **objs;
     int       i;
 
-    objs = StageObjs_800B7890;
+    objs = StageObjs;
     for (i = 32; i > 0; --i)
     {
         *objs++ = NULL;
     }
 
-    N_StageObjs_800ABAA4 = 0;
+    N_StageObjs = 0;
     gMapCount_800ABAA8 = 0;
     gMapsChanged_800ABAAC = 0;
 }
@@ -484,13 +484,17 @@ void GM_ReshadeObjs( DG_OBJS *obj )
     }
 }
 
+/*
+   すべてのマップモデルデータの Reshade   ( 使っていない？ )
+*/
+
 void GM_ReshadeMapAll( void )
 {
     DG_OBJS **obj;
     int       i;
 
-    obj = StageObjs_800B7890;
-    for (i = N_StageObjs_800ABAA4; i > 0; i--)
+    obj = StageObjs;
+    for (i = N_StageObjs; i > 0; i--)
     {
         GM_ReshadeObjs(*obj);
         obj++;

--- a/source/game/over.c
+++ b/source/game/over.c
@@ -424,7 +424,7 @@ static void DrawBackgroundFade(Work *work, u_long *ot, int shade)
     setTile(tile);
     setSemiTrans(tile, 1);
     setXY0(tile, 0, 0);
-    setWH(tile, 320, 240);
+    setWH(tile, SCREEN_WIDTH, SCREEN_HEIGHT);
     addPrim(ot, tile);
 
     tpage = &work->fade_tpage[GV_Clock];

--- a/source/game/script.c
+++ b/source/game/script.c
@@ -31,66 +31,7 @@ char         SECTION(".sbss") * GM_StageName;
 
 /*---------------------------------------------------------------------------*/
 
-STATIC int GM_Command_light(unsigned char *);
-STATIC int GM_Command_camera(unsigned char *);
-STATIC int GM_Command_map(unsigned char *);
-STATIC int GM_Command_mapdef(unsigned char *);
-STATIC int GM_Command_trap(unsigned char *);
-STATIC int GM_Command_ntrap(unsigned char *);
-STATIC int GM_Command_delay(unsigned char *);
-STATIC int GM_Command_mesg(unsigned char *);
-STATIC int GM_Command_chara(int argc, char **argv);
-STATIC int GM_Command_start(unsigned char *);
-STATIC int GM_Command_load(unsigned char *);
-STATIC int GM_Command_radio(unsigned char *);
-STATIC int GM_Command_restart(unsigned char *);
-STATIC int GM_Command_varsave(unsigned char *);
-STATIC int GM_Command_system(unsigned char *);
-STATIC int GM_Command_demo(unsigned char *);
-STATIC int GM_Command_pad(unsigned char *);
-STATIC int GM_Command_sound(unsigned char *);
-STATIC int GM_Command_menu(unsigned char *);
-STATIC int GM_Command_rand(unsigned char *);
-STATIC int GM_Command_func(unsigned char *);
-STATIC int GM_Command_demodebug(unsigned char *);
-STATIC int GM_Command_print(unsigned char *);
-STATIC int GM_Command_jimaku(unsigned char *);
-
-STATIC GCL_COMMANDLIST Commands[] = {
-    { CMD_mesg,      GM_Command_mesg        },  // GV_StrCode("mesg")
-    { CMD_trap,      GM_Command_trap        },  // GV_StrCode("trap")
-    // TODO: Why does this one have a different signature?
-    // Putting a breakpoint GM_Command_chara shows it receives
-    // trash argc and argv.
-    { CMD_chara, (GCL_COMMANDFUNC)GM_Command_chara },  // GV_StrCode("chara")
-    { CMD_map,       GM_Command_map         },  // GV_StrCode("map")
-    { CMD_mapdef,    GM_Command_mapdef      },  // GV_StrCode("mapdef")
-    { CMD_camera,    GM_Command_camera      },  // GV_StrCode("camera")
-    { CMD_light,     GM_Command_light       },  // GV_StrCode("light")
-    { CMD_start,     GM_Command_start       },  // GV_StrCode("start")
-    { CMD_load,      GM_Command_load        },  // GV_StrCode("load")
-    { CMD_radio,     GM_Command_radio       },  // GV_StrCode("radio")
-    { CMD_restart,   GM_Command_restart     },  // GV_StrCode("restart")
-    { CMD_demo,      GM_Command_demo        },  // GV_StrCode("demo")
-    { CMD_ntrap,     GM_Command_ntrap       },  // GV_StrCode("ntrap")
-    { CMD_delay,     GM_Command_delay       },  // GV_StrCode("delay")
-    { CMD_pad,       GM_Command_pad         },  // GV_StrCode("pad")
-    { CMD_varsave,   GM_Command_varsave     },  // GV_StrCode("varsave")
-    { CMD_system,    GM_Command_system      },  // GV_StrCode("system")
-    { CMD_sound,     GM_Command_sound       },  // GV_StrCode("sound")
-    { CMD_menu,      GM_Command_menu        },  // GV_StrCode("menu")
-    { CMD_rand,      GM_Command_rand        },  // GV_StrCode("rand")
-    { CMD_func,      GM_Command_func        },  // GV_StrCode("func")
-    { CMD_demodebug, GM_Command_demodebug   },  // GV_StrCode("demodebug")
-    { CMD_print,     GM_Command_print       },  // GV_StrCode("print")
-    { CMD_jimaku,    GM_Command_jimaku      }   // GV_StrCode("jimaku")
-};
-
-STATIC GCL_COMMANDDEF script_commands = { 0, COUNTOF(Commands), Commands };
-
-/*---------------------------------------------------------------------------*/
-
-STATIC int GM_Command_light(unsigned char *top)
+static int GM_Command_light(unsigned char *top)
 {
     char *light_dir;
     char *light_col;
@@ -126,7 +67,7 @@ proc AGL_FIRST_VF {
             -3362,1759,4936 -2475,770,6672 1
 */
 
-STATIC int GM_Command_camera(unsigned char *top)
+static int GM_Command_camera(unsigned char *top)
 {
     int     isEnabled, param_p, camera_id;
     SVECTOR vec1, vec2;
@@ -212,7 +153,7 @@ STATIC int GM_Command_camera(unsigned char *top)
 
 /*---------------------------------------------------------------------------*/
 
-STATIC int GM_Command_map(unsigned char *top)
+static int GM_Command_map(unsigned char *top)
 {
     MAP *pMapRecord;
     SVECTOR       colourVec;
@@ -289,7 +230,7 @@ STATIC int GM_Command_map(unsigned char *top)
 
 /*---------------------------------------------------------------------------*/
 
-STATIC int GM_Command_mapdef(unsigned char *top)
+static int GM_Command_mapdef(unsigned char *top)
 {
     if (!GM_CreateMap())
     {
@@ -301,7 +242,7 @@ STATIC int GM_Command_mapdef(unsigned char *top)
 
 /*---------------------------------------------------------------------------*/
 
-STATIC int GM_Command_trap(unsigned char *top)
+static int GM_Command_trap(unsigned char *top)
 {
     HZD_BIND *pBind;
     int         i, arg, code, value;
@@ -355,7 +296,7 @@ STATIC int GM_Command_trap(unsigned char *top)
 
 /*---------------------------------------------------------------------------*/
 
-STATIC int GM_Command_ntrap(unsigned char *top)
+static int GM_Command_ntrap(unsigned char *top)
 {
     // int bindIdx;
     HZD_BIND *pBind;
@@ -467,7 +408,7 @@ STATIC int GM_Command_ntrap(unsigned char *top)
 
 /*---------------------------------------------------------------------------*/
 
-STATIC int GM_Command_delay(unsigned char *top)
+static int GM_Command_delay(unsigned char *top)
 {
     int time = 0;
     int proc = 0;
@@ -501,7 +442,7 @@ STATIC int GM_Command_delay(unsigned char *top)
 
 /*---------------------------------------------------------------------------*/
 
-STATIC int GM_Command_mesg(unsigned char *top)
+static int GM_Command_mesg(unsigned char *top)
 {
     unsigned char *uParm1;
     int            iVar1;
@@ -532,7 +473,7 @@ STATIC int GM_Command_mesg(unsigned char *top)
 
 /*---------------------------------------------------------------------------*/
 
-STATIC int GM_Command_chara(int argc, char **argv)
+static int GM_Command_chara(int argc, char **argv)
 {
     int         ret;
     int         name;
@@ -554,7 +495,7 @@ STATIC int GM_Command_chara(int argc, char **argv)
 
 /*---------------------------------------------------------------------------*/
 
-STATIC int GM_Command_start(unsigned char *top)
+static int GM_Command_start(unsigned char *top)
 {
     if (GCL_GetOption('s'))
     {
@@ -595,7 +536,7 @@ STATIC int GM_Command_start(unsigned char *top)
 
 /*---------------------------------------------------------------------------*/
 
-STATIC int GM_Command_load(unsigned char *top)
+static int GM_Command_load(unsigned char *top)
 {
     char *scriptStageName;
     SVECTOR vec;
@@ -670,7 +611,7 @@ STATIC int GM_Command_load(unsigned char *top)
 
 /*---------------------------------------------------------------------------*/
 
-STATIC int GM_Command_radio(unsigned char *top)
+static int GM_Command_radio(unsigned char *top)
 {
     int contactFrequency;
     int radioTableCode;
@@ -746,7 +687,7 @@ STATIC int GM_Command_radio(unsigned char *top)
 
 /*---------------------------------------------------------------------------*/
 
-STATIC int GM_Command_restart(unsigned char *top)
+static int GM_Command_restart(unsigned char *top)
 {
     int proc_id;
 
@@ -776,7 +717,7 @@ STATIC int GM_Command_restart(unsigned char *top)
 
 /*---------------------------------------------------------------------------*/
 
-STATIC int GM_Command_varsave(unsigned char *top)
+static int GM_Command_varsave(unsigned char *top)
 {
     unsigned char *param;
 
@@ -799,7 +740,7 @@ STATIC int GM_Command_varsave(unsigned char *top)
 
 /*---------------------------------------------------------------------------*/
 
-STATIC int GM_Command_system(unsigned char *top)
+static int GM_Command_system(unsigned char *top)
 {
     static char options[5] = "gcawi";
 
@@ -827,7 +768,7 @@ STATIC int GM_Command_system(unsigned char *top)
 
 /*---------------------------------------------------------------------------*/
 
-STATIC int GM_Command_demo(unsigned char *top)
+static int GM_Command_demo(unsigned char *top)
 {
     int   code, cb_proc;
     char  *msg;
@@ -881,7 +822,7 @@ STATIC int GM_Command_demo(unsigned char *top)
 
 /*---------------------------------------------------------------------------*/
 
-STATIC int GM_Command_pad(unsigned char *top)
+static int GM_Command_pad(unsigned char *top)
 {
     if (GCL_GetOption('m'))
     {
@@ -902,7 +843,7 @@ STATIC int GM_Command_pad(unsigned char *top)
 
 /*---------------------------------------------------------------------------*/
 
-STATIC int GM_Command_sound(unsigned char *top)
+static int GM_Command_sound(unsigned char *top)
 {
     GM_Command_sound_impl();
     return 0;
@@ -910,7 +851,7 @@ STATIC int GM_Command_sound(unsigned char *top)
 
 /*---------------------------------------------------------------------------*/
 
-STATIC unsigned int GM_Command_menu_helper(void)
+static unsigned int GM_Command_menu_helper(void)
 {
     unsigned int ret = 0;
     int next;
@@ -930,7 +871,7 @@ STATIC unsigned int GM_Command_menu_helper(void)
     return ret;
 }
 
-STATIC int GM_Command_menu(unsigned char *top)
+static int GM_Command_menu(unsigned char *top)
 {
     if (GCL_GetOption('j'))
     {
@@ -1035,7 +976,7 @@ STATIC int GM_Command_menu(unsigned char *top)
 
 /*---------------------------------------------------------------------------*/
 
-STATIC int GM_Command_rand(unsigned char *top)
+static int GM_Command_rand(unsigned char *top)
 {
     int param;
     int randValue;
@@ -1048,7 +989,7 @@ STATIC int GM_Command_rand(unsigned char *top)
 
 /*---------------------------------------------------------------------------*/
 
-STATIC int GM_Command_func(unsigned char *top)
+static int GM_Command_func(unsigned char *top)
 {
     SVECTOR     vec;
     CONTROL    *control;
@@ -1112,7 +1053,7 @@ STATIC int GM_Command_func(unsigned char *top)
 
 int demodebug_finish_proc = -1;
 
-STATIC int GM_Command_demodebug(unsigned char *top)
+static int GM_Command_demodebug(unsigned char *top)
 {
     int   tmp, demo, flags, ivar;
     char *filename;
@@ -1165,7 +1106,7 @@ STATIC int GM_Command_demodebug(unsigned char *top)
 
 /*---------------------------------------------------------------------------*/
 
-STATIC int GM_Command_print(unsigned char *top)
+static int GM_Command_print(unsigned char *top)
 {
     int code;
     int value;
@@ -1189,13 +1130,45 @@ STATIC int GM_Command_print(unsigned char *top)
 
 /*---------------------------------------------------------------------------*/
 
-STATIC int GM_Command_jimaku(unsigned char *top)
+static int GM_Command_jimaku(unsigned char *top)
 {
     NewJimaku();
     return 0;
 }
 
 /*---------------------------------------------------------------------------*/
+
+STATIC GCL_COMMANDLIST Commands[] = {
+    { CMD_mesg,      GM_Command_mesg        },  // GV_StrCode("mesg")
+    { CMD_trap,      GM_Command_trap        },  // GV_StrCode("trap")
+    // TODO: Why does this one have a different signature?
+    // Putting a breakpoint GM_Command_chara shows it receives
+    // trash argc and argv.
+    { CMD_chara, (GCL_COMMANDFUNC)GM_Command_chara },  // GV_StrCode("chara")
+    { CMD_map,       GM_Command_map         },  // GV_StrCode("map")
+    { CMD_mapdef,    GM_Command_mapdef      },  // GV_StrCode("mapdef")
+    { CMD_camera,    GM_Command_camera      },  // GV_StrCode("camera")
+    { CMD_light,     GM_Command_light       },  // GV_StrCode("light")
+    { CMD_start,     GM_Command_start       },  // GV_StrCode("start")
+    { CMD_load,      GM_Command_load        },  // GV_StrCode("load")
+    { CMD_radio,     GM_Command_radio       },  // GV_StrCode("radio")
+    { CMD_restart,   GM_Command_restart     },  // GV_StrCode("restart")
+    { CMD_demo,      GM_Command_demo        },  // GV_StrCode("demo")
+    { CMD_ntrap,     GM_Command_ntrap       },  // GV_StrCode("ntrap")
+    { CMD_delay,     GM_Command_delay       },  // GV_StrCode("delay")
+    { CMD_pad,       GM_Command_pad         },  // GV_StrCode("pad")
+    { CMD_varsave,   GM_Command_varsave     },  // GV_StrCode("varsave")
+    { CMD_system,    GM_Command_system      },  // GV_StrCode("system")
+    { CMD_sound,     GM_Command_sound       },  // GV_StrCode("sound")
+    { CMD_menu,      GM_Command_menu        },  // GV_StrCode("menu")
+    { CMD_rand,      GM_Command_rand        },  // GV_StrCode("rand")
+    { CMD_func,      GM_Command_func        },  // GV_StrCode("func")
+    { CMD_demodebug, GM_Command_demodebug   },  // GV_StrCode("demodebug")
+    { CMD_print,     GM_Command_print       },  // GV_StrCode("print")
+    { CMD_jimaku,    GM_Command_jimaku      }   // GV_StrCode("jimaku")
+};
+
+STATIC GCL_COMMANDDEF script_commands = { 0, COUNTOF(Commands), Commands };
 
 int GM_InitBinds(void)
 {

--- a/source/game/sound.c
+++ b/source/game/sound.c
@@ -13,7 +13,7 @@ STATIC void sub_8003214C(SVECTOR *pVec, int *pRet)
 {
     MATRIX *eye;
 
-    eye = &DG_Chanl(0)->field_30_eye;
+    eye = &DG_Chanl(0)->eye;
     pVec->vx = eye->t[0];
     pVec->vy = eye->t[1];
     pVec->vz = eye->t[2];

--- a/source/include/psxdefs.h
+++ b/source/include/psxdefs.h
@@ -8,4 +8,7 @@
 // we now have to cast them to avoid warnings.
 typedef long (*openevent_cb_t)();
 
+/* scratch pad address 0x1f800000 - 0x1f800400 */
+#define getScratchAddr2(type, offset)   ((type *)(0x1f800000+(offset)))
+
 #endif // __MGS_PSXDEFS_H__

--- a/source/kojo/demo.c
+++ b/source/kojo/demo.c
@@ -486,7 +486,7 @@ int FrameRunDemo(DemoWork *work, DMO_DAT *data)
     gUnkCameraStruct2_800B7868.center.vy = data->center_y;
     gUnkCameraStruct2_800B7868.center.vz = data->center_z;
 
-    DG_Chanl(0)->field_50_clip_distance = data->clip_dist;
+    DG_Chanl(0)->clip_distance = data->clip_dist;
 
     diff.vx = data->center_x - data->eye_x;
     diff.vy = data->center_y - data->eye_y;
@@ -506,15 +506,15 @@ int FrameRunDemo(DemoWork *work, DMO_DAT *data)
 
     rot.vz = data->roll;
     DG_RotatePos(&rot);
-    ReadRotMatrix(&DG_Chanl(0)->field_30_eye);
+    ReadRotMatrix(&DG_Chanl(0)->eye);
 
-    DG_TransposeMatrix(&DG_Chanl(0)->field_30_eye, &DG_Chanl(0)->field_10_eye_inv);
+    DG_TransposeMatrix(&DG_Chanl(0)->eye, &DG_Chanl(0)->eye_inv);
 
-    trans.vx = -DG_Chanl(0)->field_30_eye.t[0];
-    trans.vy = -DG_Chanl(0)->field_30_eye.t[1];
-    trans.vz = -DG_Chanl(0)->field_30_eye.t[2];
+    trans.vx = -DG_Chanl(0)->eye.t[0];
+    trans.vy = -DG_Chanl(0)->eye.t[1];
+    trans.vz = -DG_Chanl(0)->eye.t[2];
 
-    ApplyMatrixLV(&DG_Chanl(0)->field_10_eye_inv, &trans, (VECTOR *)DG_Chanl(0)->field_10_eye_inv.t);
+    ApplyMatrixLV(&DG_Chanl(0)->eye_inv, &trans, (VECTOR *)DG_Chanl(0)->eye_inv.t);
     return 1;
 }
 
@@ -3570,12 +3570,12 @@ void DemoScreenChanl(DG_CHANL *chanl, int idx)
     ppObjs = chanl->mQueue;
 
     scrpad = (SCREEN_SPAD *)getScratchAddr(0);
-    scrpad->matrix = chanl->field_10_eye_inv;
+    scrpad->matrix = chanl->eye_inv;
     scrpad->matrix.t[0] = scrpad->matrix.t[1] = scrpad->matrix.t[2] = 0;
 
-    scrpad->translation[0] = chanl->field_30_eye.t[0];
-    scrpad->translation[1] = chanl->field_30_eye.t[1];
-    scrpad->translation[2] = chanl->field_30_eye.t[2];
+    scrpad->translation[0] = chanl->eye.t[0];
+    scrpad->translation[1] = chanl->eye.t[1];
+    scrpad->translation[2] = chanl->eye.t[2];
 
     DG_AdjustOverscan(&scrpad->matrix);
 

--- a/source/libdg/bound.c
+++ b/source/libdg/bound.c
@@ -201,7 +201,7 @@ void DG_BoundChanl(DG_CHANL *chanl, int idx)
     long        *test;
     unsigned int flag;
 
-    DG_Clip(&chanl->field_5C_clip_rect, chanl->field_50_clip_distance);
+    DG_Clip(&chanl->clip_rect, chanl->clip_distance);
 
     objs = chanl->mQueue;
     n_objs = chanl->mTotalObjectCount;

--- a/source/libdg/chanl.c
+++ b/source/libdg/chanl.c
@@ -118,6 +118,7 @@ void DG_InitChanlSystem( int width )
     DrawSyncCallback(DG_DrawSyncCallback);
     dword_800AB978 = width;
 
+    /* channel 0 */
     chanl = DG_Chanls;
     DG_SetChanlOrderingTable(chanl, (unsigned char *)dword_800B0630, 5, (DG_OBJS **)dword_800B0F60, 8, -1, 1);
     DG_InitDrawEnv(&drawEnv, 0, 0, FRAME_WIDTH, FRAME_HEIGHT);
@@ -126,6 +127,7 @@ void DG_InitChanlSystem( int width )
     DG_CopyChanlDrawEnv(chanl, 0);
     DG_CopyChanlDrawEnv(chanl, 1);
 
+    /* channel 1 */
     chanl++;
     DG_SetChanlOrderingTable(chanl, (unsigned char *)dword_800B0740, 8, (DG_OBJS **)dword_800B0F80, 256, 16, 1);
     DG_InitDrawEnv(&drawEnv, 0, 0, FRAME_WIDTH, FRAME_HEIGHT);
@@ -138,6 +140,7 @@ void DG_InitChanlSystem( int width )
     chanl->field_EC_dr_env[0] = stru_800B1380[0];
     chanl->field_EC_dr_env[1] = stru_800B1380[1];
 
+    /* channel 2 */
     chanl++;
     DG_SetChanlOrderingTable(chanl, (unsigned char *)dword_800B0F50, 0, 0, 0, 8, 1);
     DG_InitDrawEnv(&drawEnv, 0, 0, FRAME_WIDTH, FRAME_HEIGHT);

--- a/source/libdg/chanl.c
+++ b/source/libdg/chanl.c
@@ -32,7 +32,7 @@ short          SECTION(".sbss") word_800AB982;
 unsigned short SECTION(".sbss") gCurrentRootCnt_800AB984;
 
 /*** bss ***/
-extern DG_CHANL       DG_Chanls_800B1800[3];
+extern DG_CHANL       DG_Chanls[3];
 extern int            dword_800B0630[68];
 extern int            dword_800B0740[516];
 extern int            dword_800B0F50[4];
@@ -58,16 +58,16 @@ STATIC void DG_SetChanlOrderingTable( DG_CHANL *chanl, unsigned char *pOtBuffer,
     // TODO: Aligning the end ptr? Also not sure if type is correct
     unsigned char *pEnd = pOtBuffer + ((((1 << (otLen))) + 1) * 4);
 
-    chanl->mOrderingTables[0] = pOtBuffer;
-    chanl->mOrderingTables[1] = pEnd;
+    chanl->ot[0] = pOtBuffer;
+    chanl->ot[1] = pEnd;
     chanl->mTotalObjectCount = 0;
     chanl->mQueue = pQueue;
-    chanl->word_6BC374_8 = otLen;
-    chanl->word_6BC37A_0_1EC_size = 0;
+    chanl->field_08 = otLen;
+    chanl->field_0E_size = 0;
     chanl->mFreePrimCount = queueSize;
     chanl->mTotalQueueSize = queueSize;
-    chanl->word_6BC376_16 = param_6;
-    chanl->word_6BC378_1 = param_7;
+    chanl->field_0A = param_6;
+    chanl->field_0C = param_7;
 }
 
 // guessed function name
@@ -79,7 +79,7 @@ STATIC void DG_SetChanlDrawEnv( DG_CHANL *chanl, DRAWENV *pDrawEnv, int backroun
     drawEnv = *pDrawEnv;
     x_off = 0;
 
-    if (chanl->word_6BC378_1)
+    if (chanl->field_0C)
     {
         x_off = dword_800AB978;
     }
@@ -105,7 +105,7 @@ STATIC void DG_SetChanlDrawEnv( DG_CHANL *chanl, DRAWENV *pDrawEnv, int backroun
 // guessed function name
 STATIC void DG_CopyChanlDrawEnv( DG_CHANL *chanl, int idx )
 {
-    chanl->field_5C_clip_rect = chanl->field_64_rect;
+    chanl->clip_rect = chanl->field_64_rect;
     chanl->field_6C_dr_env[idx] = chanl->field_16C_dr_env[idx];
 }
 
@@ -118,7 +118,7 @@ void DG_InitChanlSystem( int width )
     DrawSyncCallback(DG_DrawSyncCallback);
     dword_800AB978 = width;
 
-    chanl = DG_Chanls_800B1800;
+    chanl = DG_Chanls;
     DG_SetChanlOrderingTable(chanl, (unsigned char *)dword_800B0630, 5, (DG_OBJS **)dword_800B0F60, 8, -1, 1);
     DG_InitDrawEnv(&drawEnv, 0, 0, 320, 224);
     drawEnv.isbg = 1;
@@ -153,7 +153,7 @@ void DG_DrawOTag( int activeBuffer )
 {
     gOldRootCnt_800B1DC8[0] = gCurrentRootCnt_800AB984;
     gCurrentRootCnt_800AB984 = GetRCnt(RCntCNT1);
-    DrawOTag((u_long *)&DG_Chanls_800B1800[0].field_6C_dr_env[activeBuffer]);
+    DrawOTag((u_long *)&DG_Chanls[0].field_6C_dr_env[activeBuffer]);
 }
 
 // not correct, revisit;
@@ -170,23 +170,23 @@ void DG_ClearChanlSystem( int which )
     int v2;
 
     unsigned long *ots;
-    chanl = DG_Chanls_800B1800;
+    chanl = DG_Chanls;
 
     for (i = 3; i > 0; --i)
     {
         // loc_80017EF8
-        ots = (unsigned long *)chanl->mOrderingTables[which];
+        ots = (unsigned long *)chanl->ot[which];
         ot = ots;
-        n_ot = pow2(chanl->word_6BC374_8);
+        n_ot = pow2(chanl->field_08);
         s4 = (unsigned int)&ot[n_ot];
 
         ClearOTagR(ot, n_ot + 1);
 
-        if (chanl->word_6BC37A_0_1EC_size > 0)
+        if (chanl->field_0E_size > 0)
         {
             // loc_80017F30
             DG_CopyChanlDrawEnv(chanl, which);
-            --chanl->word_6BC37A_0_1EC_size;
+            --chanl->field_0E_size;
         }
 
         // loc_80017F50
@@ -203,11 +203,11 @@ void DG_ClearChanlSystem( int which )
 
         ot[0] = v1 | v0;
 
-        if (chanl->word_6BC376_16 >= 0)
+        if (chanl->field_0A >= 0)
         {
             // loc_80017F94
-            ot = (unsigned long *)DG_Chanls_800B1800[0].mOrderingTables[which];
-            ot = &ot[chanl->word_6BC376_16];
+            ot = (unsigned long *)DG_Chanls[0].ot[which];
+            ot = &ot[chanl->field_0A];
 
             // addPrims(ot, draw_env, draw_env2); //should do the below
             draw_env2->tag = (draw_env2->tag & 0xFF000000) | (ot[0] & 0x00FFFFFF);
@@ -259,7 +259,7 @@ void DG_RenderPipeline( int idx )
         {
             *pPerfArrayIter++ = GetRCnt(RCntCNT1);
             // Call the render func, saving the time of the previous pass
-            (*chanlfunc)(&DG_Chanls_800B1800[1], idx);
+            (*chanlfunc)(&DG_Chanls[1], idx);
             chanlfunc++;
         }
         *pPerfArrayIter++ = GetRCnt(RCntCNT1);
@@ -269,9 +269,9 @@ void DG_RenderPipeline( int idx )
 
 void DG_SetRenderChanlDrawEnv( int idx, DRAWENV *pDrawEnv )
 {
-    DG_CHANL *chanl = &DG_Chanls_800B1800[idx + 1];
+    DG_CHANL *chanl = &DG_Chanls[idx + 1];
     DG_SetChanlDrawEnv(chanl, pDrawEnv, 0);
-    chanl->word_6BC37A_0_1EC_size = 2;
+    chanl->field_0E_size = 2;
 }
 
 int DG_QueueObjs( DG_OBJS *objs )
@@ -280,7 +280,7 @@ int DG_QueueObjs( DG_OBJS *objs )
     int       n_chanl, n_objs;
 
     n_chanl = objs->chanl + 1;
-    chanl = &DG_Chanls_800B1800[n_chanl];
+    chanl = &DG_Chanls[n_chanl];
 
     n_objs = chanl->mTotalObjectCount;
 
@@ -303,7 +303,7 @@ void DG_DequeueObjs( DG_OBJS *objs )
     DG_OBJS **chanl_objs;
 
     n_chanl = objs->chanl + 1;
-    chanl = &DG_Chanls_800B1800[n_chanl];
+    chanl = &DG_Chanls[n_chanl];
 
     n_objs = chanl->mTotalObjectCount;
     chanl_objs = chanl->mQueue;
@@ -331,7 +331,7 @@ END:
 int DG_QueuePrim( DG_PRIM *prim )
 {
     int       t = prim->chanl + 1;
-    DG_CHANL *chanl = &DG_Chanls_800B1800[t];
+    DG_CHANL *chanl = &DG_Chanls[t];
     int       idx = chanl->mFreePrimCount;
 
     if (idx <= chanl->mTotalObjectCount)
@@ -355,7 +355,7 @@ void DG_DequeuePrim( DG_PRIM *prim )
     DG_OBJS **chanl_objs;
 
     group = prim->chanl + 1;
-    chanl = &DG_Chanls_800B1800[group];
+    chanl = &DG_Chanls[group];
 
     n_free_prims = chanl->mFreePrimCount;
     queue_size = chanl->mTotalQueueSize;
@@ -403,7 +403,7 @@ void DG_FreeObjectQueue( void )
     DG_OBJS  *objs;
     int       i;
 
-    chanl = &DG_Chanls_800B1800[1];
+    chanl = &DG_Chanls[1];
     queue = (DG_OBJS **)chanl->mQueue;
 
     DG_ObjectQueueVoided = TRUE;
@@ -425,13 +425,13 @@ void DG_RestartMainChanlSystem( void )
 void DG_SetBackgroundRGB( int r, int g, int b )
 {
     DRAWENV drawEnv;
-    DG_CHANL *chanl = &DG_Chanls_800B1800[0];
+    DG_CHANL *chanl = &DG_Chanls[0];
 
     DG_InitDrawEnv(&drawEnv, 0, 0, 320, 224);
     drawEnv.isbg = 1;
     setRGB0(&drawEnv, r, g, b);
     DG_SetChanlDrawEnv(chanl, &drawEnv, 1);
-    chanl->word_6BC37A_0_1EC_size = 2;
+    chanl->field_0E_size = 2;
 }
 
 void DG_SetRGB( int r, int g, int b )

--- a/source/libdg/chanl.c
+++ b/source/libdg/chanl.c
@@ -120,7 +120,7 @@ void DG_InitChanlSystem( int width )
 
     chanl = DG_Chanls;
     DG_SetChanlOrderingTable(chanl, (unsigned char *)dword_800B0630, 5, (DG_OBJS **)dword_800B0F60, 8, -1, 1);
-    DG_InitDrawEnv(&drawEnv, 0, 0, 320, 224);
+    DG_InitDrawEnv(&drawEnv, 0, 0, FRAME_WIDTH, FRAME_HEIGHT);
     drawEnv.isbg = 1;
     DG_SetChanlDrawEnv(chanl, &drawEnv, 1);
     DG_CopyChanlDrawEnv(chanl, 0);
@@ -128,7 +128,7 @@ void DG_InitChanlSystem( int width )
 
     chanl++;
     DG_SetChanlOrderingTable(chanl, (unsigned char *)dword_800B0740, 8, (DG_OBJS **)dword_800B0F80, 256, 16, 1);
-    DG_InitDrawEnv(&drawEnv, 0, 0, 320, 224);
+    DG_InitDrawEnv(&drawEnv, 0, 0, FRAME_WIDTH, FRAME_HEIGHT);
     drawEnv.ofs[0] = 160;
     drawEnv.ofs[1] = 112;
     DG_SetChanlDrawEnv(chanl, &drawEnv, 0);
@@ -140,7 +140,7 @@ void DG_InitChanlSystem( int width )
 
     chanl++;
     DG_SetChanlOrderingTable(chanl, (unsigned char *)dword_800B0F50, 0, 0, 0, 8, 1);
-    DG_InitDrawEnv(&drawEnv, 0, 0, 320, 224);
+    DG_InitDrawEnv(&drawEnv, 0, 0, FRAME_WIDTH, FRAME_HEIGHT);
     DG_SetChanlDrawEnv(chanl, &drawEnv, 0);
     DG_CopyChanlDrawEnv(chanl, 0);
     DG_CopyChanlDrawEnv(chanl, 1);
@@ -427,7 +427,7 @@ void DG_SetBackgroundRGB( int r, int g, int b )
     DRAWENV drawEnv;
     DG_CHANL *chanl = &DG_Chanls[0];
 
-    DG_InitDrawEnv(&drawEnv, 0, 0, 320, 224);
+    DG_InitDrawEnv(&drawEnv, 0, 0, FRAME_WIDTH, FRAME_HEIGHT);
     drawEnv.isbg = 1;
     setRGB0(&drawEnv, r, g, b);
     DG_SetChanlDrawEnv(chanl, &drawEnv, 1);

--- a/source/libdg/dgd.c
+++ b/source/libdg/dgd.c
@@ -134,8 +134,8 @@ void DG_StartDaemon(void)
     mts_set_vsync_task();
     mts_set_vsync_callback_func(DG_VSyncCallbackFunc);
 
-    DG_InitDispEnv(0, 0, 320, 240, 320);
-    DG_InitChanlSystem(320);
+    DG_InitDispEnv(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT, 320);
+    DG_InitChanlSystem(SCREEN_WIDTH);
     DG_ClearResidentTexture();
     DG_ResetPipeline();
 

--- a/source/libdg/display.c
+++ b/source/libdg/display.c
@@ -46,9 +46,45 @@ void DG_InitDispEnv(int x, short y, short w, short h, int clipH)
     gClipHeights_800AB960[1] = x + clipH;
 }
 
-void DG_ChangeReso(int arg0)
+void DG_ChangeReso(int flag)
 {
-    /* do nothing */
+#if 0
+    DRAWENV drawenv;
+
+    if ((flag & 1) == 0) {
+        g_dispenv.disp.w = 320;
+        g_dispenv.screen.x = 0;
+        g_dispenv.screen.w = 255;
+    } else {
+        g_dispenv.disp.w = 384;
+        g_dispenv.screen.x = 26;
+        g_dispenv.screen.w = 212;
+    }
+
+    if ((flag & 2) == 0) {
+        g_dispenv.screen.h = 256;
+    } else {
+        g_dispenv.screen.h = 224;
+    }
+
+    g_dispenv.screen.y = 16;
+
+    if ((flag & 4) == 0) {
+        g_dispenv.disp.y = 0;
+        g_dispenv.disp.h = 256;
+    } else {
+        g_dispenv.disp.h = 224;
+        g_dispenv.disp.y = (g_dispenv.screen.h - 224) / 2;
+    }
+
+    if ((flag & 8) != 0) {
+        PutDispEnv(&g_dispenv);
+    }
+
+    SetDefDrawEnv(&drawenv, 0, 0, 320, g_dispenv.disp.h);
+    drawenv.isbg = 1;
+    DG_SetRenderChanlDrawEnv(-1, &drawenv);
+#endif
 }
 
 void DG_RenderPipeline_Init(void)

--- a/source/libdg/display.c
+++ b/source/libdg/display.c
@@ -40,7 +40,7 @@ void DG_InitDispEnv(int x, short y, short w, short h, int clipH)
 
     // For some reason lets overwrite what we already setup
     pDispEnv->screen.y = 8;
-    pDispEnv->screen.h = 224;
+    pDispEnv->screen.h = FRAME_HEIGHT;
 
     gClipHeights_800AB960[0] = x;
     gClipHeights_800AB960[1] = x + clipH;
@@ -254,8 +254,8 @@ void DG_FadeScreen(int amount)
 
     tile.x0 = 0;
     tile.y0 = 0;
-    tile.w = 320;
-    tile.h = 224;
+    tile.w = FRAME_WIDTH;
+    tile.h = FRAME_HEIGHT;
     LSTORE(amount << 16 | amount << 8 | amount, &tile.r0);
     setTile(&tile);
     setSemiTrans(&tile, 1);

--- a/source/libdg/display.c
+++ b/source/libdg/display.c
@@ -107,9 +107,9 @@ void DG_LookAt(DG_CHANL *chanl, SVECTOR *eye, SVECTOR *center, int clip_distance
     VECTOR  right;
     MATRIX *view;
 
-    chanl->field_50_clip_distance = clip_distance;
+    chanl->clip_distance = clip_distance;
 
-    view = &chanl->field_30_eye;
+    view = &chanl->eye;
     view->t[0] = eye->vx;
     view->t[1] = eye->vy;
     view->t[2] = eye->vz;
@@ -146,13 +146,13 @@ void DG_LookAt(DG_CHANL *chanl, SVECTOR *eye, SVECTOR *center, int clip_distance
     view->m[2][1] = up.vz;
     view->m[2][2] = forward.vz;
 
-    DG_TransposeMatrix(view, &chanl->field_10_eye_inv);
+    DG_TransposeMatrix(view, &chanl->eye_inv);
 
     forward.vx = -view->t[0];
     forward.vy = -view->t[1];
     forward.vz = -view->t[2];
 
-    ApplyMatrixLV(&chanl->field_10_eye_inv, &forward, (VECTOR *)chanl->field_10_eye_inv.t);
+    ApplyMatrixLV(&chanl->eye_inv, &forward, (VECTOR *)chanl->eye_inv.t);
 }
 
 void DG_AdjustOverscan(MATRIX *matrix)

--- a/source/libdg/divide.c
+++ b/source/libdg/divide.c
@@ -552,13 +552,13 @@ void DG_DivideChanl( DG_CHANL *chanl, int idx )
 
     if ( !DG_InitDividePacks( idx ) ) return;
 
-    DG_Clip( &chanl->field_5C_clip_rect, chanl->field_50_clip_distance );
+    DG_Clip( &chanl->clip_rect, chanl->clip_distance );
 
     divide_mem = GetDivideMem();
     divide_mem->ot = (long *)ptr_800B1400;
     divide_mem->field_14 = 0x800;
 
-    if ( chanl->field_50_clip_distance > 1000)
+    if ( chanl->clip_distance > 1000)
     {
         divide_mem->field_18 = 60000;
     }

--- a/source/libdg/libdg.h
+++ b/source/libdg/libdg.h
@@ -297,19 +297,19 @@ typedef struct DG_DivideMem         // private to libdg/divide.c
 
 typedef struct DG_CHANL
 {
-    unsigned char *mOrderingTables[ 2 ]; // 257 pointers? // One for each active buffer
-    short          word_6BC374_8;
-    short          word_6BC376_16;
-    short          word_6BC378_1;
-    short          word_6BC37A_0_1EC_size;
-    MATRIX         field_10_eye_inv;
-    MATRIX         field_30_eye;
-    short          field_50_clip_distance;
+    unsigned char *ot[ 2 ]; // 257 pointers? // One for each active buffer
+    short          field_08;
+    short          field_0A;
+    short          field_0C;
+    short          field_0E_size;
+    MATRIX         eye_inv;
+    MATRIX         eye;
+    short          clip_distance;
     short          mTotalQueueSize;
     short          mFreePrimCount;
     short          mTotalObjectCount;
     DG_OBJS      **mQueue; // queue can contain DG_PRIM as well, probably void*
-    RECT           field_5C_clip_rect;
+    RECT           clip_rect;
     RECT           field_64_rect;
     // One for each active buffer and for some reason passed as the root
     // to DrawOTag
@@ -384,9 +384,6 @@ enum DG_CHANL
     DG_SORT_CHANL,
     DG_CHANL_UNIT_MAX
 };
-
-//#define WEAPON_FLAG ( DG_FLAG_TEXT | DG_FLAG_TRANS | DG_FLAG_GBOUND | DG_FLAG_SHADE |\
-//                    DG_FLAG_ONEPIECE) // 0x6d
 
 // TODO: these belong to takabe/paper.c
 #define RevisionDir( a )  a &= 4095
@@ -642,14 +639,14 @@ void DG_MakeEffectPalette( unsigned short *param_1, int param_2 );
 
 static inline DG_CHANL *DG_Chanl( int idx )
 {
-    extern DG_CHANL DG_Chanls_800B1800[ 3 ];
-    return &DG_Chanls_800B1800[ idx + 1 ];
+    extern DG_CHANL DG_Chanls[ 3 ];
+    return &DG_Chanls[ idx + 1 ];
 }
 
 static inline char *DG_ChanlOTag(int index)
 {
     extern int GV_Clock;
-    return DG_Chanl(index)->mOrderingTables[GV_Clock];
+    return DG_Chanl(index)->ot[GV_Clock];
 }
 
 static inline DG_PRIM *DG_GetPrim( int type, int prim_count, int chanl, SVECTOR *vec, RECT *pRect )

--- a/source/libdg/prim.c
+++ b/source/libdg/prim.c
@@ -509,17 +509,17 @@ void DG_PrimChanl( DG_CHANL *chanl, int idx )
     int       x;
 
     n_prims = chanl->mTotalQueueSize - chanl->mFreePrimCount;
-    clip_rect = &chanl->field_5C_clip_rect;
+    clip_rect = &chanl->clip_rect;
 
     if ( n_prims == 0 )
     {
         return;
     }
 
-    DG_Clip( clip_rect, chanl->field_50_clip_distance );
+    DG_Clip( clip_rect, chanl->clip_distance );
 
     group_id = DG_CurrentGroupID;
-    eye = &chanl->field_10_eye_inv;
+    eye = &chanl->eye_inv;
 
     queue = (DG_PRIM **)&chanl->mQueue[ chanl->mFreePrimCount ];
     for ( ; n_prims > 0 ; n_prims-- )

--- a/source/libdg/screen.c
+++ b/source/libdg/screen.c
@@ -6,7 +6,7 @@
 #include <libgpu.h>
 #include "common.h"
 
-extern DG_CHANL DG_Chanls_800B1800[3];
+extern DG_CHANL DG_Chanls[3];
 
 void DG_SetPos( MATRIX *matrix )
 {
@@ -130,7 +130,7 @@ void DG_PointCheck( SVECTOR *svector, int n_points )
 
     gte_ReadRotMatrix(matrix2);
 
-    matrix = &DG_Chanls_800B1800[1].field_10_eye_inv;
+    matrix = &DG_Chanls[1].eye_inv;
     gte_SetRotMatrix(matrix);
     gte_SetTransMatrix(matrix);
 
@@ -169,7 +169,7 @@ int DG_PointCheckOne( DVECTOR *line )
     DVECTOR first_points;
     DVECTOR second_points;
 
-    MATRIX *matrix = &DG_Chanls_800B1800[1].field_10_eye_inv;
+    MATRIX *matrix = &DG_Chanls[1].eye_inv;
     gte_SetRotMatrix(matrix);
     gte_SetTransMatrix(matrix);
 
@@ -434,7 +434,7 @@ void DG_ScreenChanl( DG_CHANL *chanl, int idx )
 
     queue = chanl->mQueue;
 
-    *(MATRIX *)getScratchAddr(0) = chanl->field_10_eye_inv;
+    *(MATRIX *)getScratchAddr(0) = chanl->eye_inv;
     DG_AdjustOverscan((MATRIX *)getScratchAddr(0));
 
     for (i = chanl->mTotalObjectCount; i > 0; i--)

--- a/source/libdg/sort.c
+++ b/source/libdg/sort.c
@@ -52,7 +52,7 @@ void DG_SortChanl( DG_CHANL *chanl, int idx )
     SCRATCHPAD_UNK *pad = get_scratch();
 
     pad->buf = ptr_800B1400;
-    pad->ot = (unsigned int *)chanl->mOrderingTables[idx] + 1;
+    pad->ot = (unsigned int *)chanl->ot[idx] + 1;
 
     buf = get_buf();
     ot = pad->ot;

--- a/source/libdg/trans.c
+++ b/source/libdg/trans.c
@@ -392,7 +392,7 @@ void DG_TransChanl( DG_CHANL *chanl, int idx )
 
     work = (SCRATCH *)getScratchAddr(0);
 
-    DG_Clip(&chanl->field_5C_clip_rect, chanl->field_50_clip_distance);
+    DG_Clip(&chanl->clip_rect, chanl->clip_distance);
 
     queue = (DG_OBJS **)chanl->mQueue;
     for (n_objects = chanl->mTotalObjectCount; n_objects > 0; n_objects--)

--- a/source/libgcl/expr.c
+++ b/source/libgcl/expr.c
@@ -7,8 +7,8 @@ static int calc(int op, int value1, int value2)
     {
     case GCL_OP_NEGATE:
         return -value2;
-    case GCL_OP_ISZERO:
-        return value2 == 0;
+    case GCL_OP_NOT:
+        return !value2;
     case GCL_OP_COMPL:
         return ~value2;
     case GCL_OP_ADD:
@@ -68,8 +68,8 @@ int GCL_Expr(unsigned char *pScript, int *retValue)
         if (code == GCLCODE_EXPR_OPERATOR)
         {
             // Operator found, process operands
-            operator= ptr[1];
-            if (!operator)
+            operator = ptr[1];
+            if (operator == 0)
             {
                 if (retValue)
                 {
@@ -77,7 +77,7 @@ int GCL_Expr(unsigned char *pScript, int *retValue)
                 }
                 return sp[-1].value;
             }
-            if (operator == GCL_OP_EQUAL)
+            if (operator == GCL_OP_ASSIGN)
             {
                 GCL_SetVar(sp[-2].ptr, sp[-1].value);
                 sp[-2].value = sp[-1].value;

--- a/source/libgcl/libgcl.h
+++ b/source/libgcl/libgcl.h
@@ -93,7 +93,7 @@ typedef struct GCL_Vars
 #define GCLCODE_PROC            0x70
 
 #define GCL_OP_NEGATE       1
-#define GCL_OP_ISZERO       2
+#define GCL_OP_NOT          2
 #define GCL_OP_COMPL        3
 #define GCL_OP_ADD          4
 #define GCL_OP_SUB          5
@@ -111,7 +111,7 @@ typedef struct GCL_Vars
 #define GCL_OP_BITXOR       17
 #define GCL_OP_OR           18
 #define GCL_OP_AND          19
-#define GCL_OP_EQUAL        20
+#define GCL_OP_ASSIGN       20
 
 #define GCL_IsVariable(gcl_code) ((gcl_code & 0xF0) == GCLCODE_VARIABLE)
 #define GCL_IsParam(gcl_code) ((gcl_code & 0xFF) == GCLCODE_PARAMETER)

--- a/source/libgv/actor.c
+++ b/source/libgv/actor.c
@@ -120,11 +120,11 @@ void GV_DumpActorSystem(void)
             if (actor->act)
             {
                 int unknown;
-                if (actor->field_1C > 0)
+                if (actor->count > 0)
                 {
                     // TODO: I've yet to see this condition be hit - perhaps an
                     // unused feature of the actor system?
-                    unknown = (actor->field_18 * 100) / actor->field_1C;
+                    unknown = (actor->runtime * 100) / actor->count;
                 }
                 else
                 {
@@ -137,8 +137,8 @@ void GV_DumpActorSystem(void)
                         actor->act,
                         actor->filename);
 
-                actor->field_1C = 0;
-                actor->field_18 = 0;
+                actor->count = 0;
+                actor->runtime = 0;
             }
 
             actor = next;
@@ -288,8 +288,8 @@ void GV_SetNamedActor(void *actor, void *act_func,
     act->act = (GV_ACTFUNC)act_func;
     act->die = (GV_ACTFUNC)die_func;
     act->filename = filename;
-    act->field_1C = 0;
-    act->field_18 = 0;
+    act->count = 0;
+    act->runtime = 0;
 }
 
 // Removes from linked list and calls shutdown/free funcs

--- a/source/libgv/libgv.h
+++ b/source/libgv/libgv.h
@@ -83,8 +83,8 @@ typedef struct _GV_ACT
     GV_ACTFUNC      die;        // shutdown callback
     GV_FREEFUNC     free;       // free callback
     const char     *filename;   // source filename
-    int             field_18;
-    int             field_1C;
+    int             runtime;
+    int             count;
 } GV_ACT;
 
 typedef struct      // private to libgv/actor.c

--- a/source/libhzd/collide.c
+++ b/source/libhzd/collide.c
@@ -5,9 +5,7 @@
 #include "inline_n.h"
 #include "inline_x.h"
 #include "game/map.h"   // for GM_IterHazard
-
-/* scratch pad address 0x1f800000 - 0x1f800400 */
-#define getScratchAddr2(type, offset)   ((type *)(0x1f800000+(offset)))
+#include "psxdefs.h"    // for getScratchAddr2
 
 typedef struct SPAD_DATA
 {

--- a/source/menu/debug.c
+++ b/source/menu/debug.c
@@ -295,8 +295,8 @@ STATIC int menu_draw_ply_debug(MenuWork *work, unsigned int *pOt)
     y_0_1 = 0xa8;
     y_2_3 = 0xa8;
 
-    chnlOt = DG_Chanl(0)->mOrderingTables[1 - GV_Clock];
-    numOTEntries = DG_Chanl(0)->word_6BC374_8 - 4;
+    chnlOt = DG_Chanl(0)->ot[1 - GV_Clock];
+    numOTEntries = DG_Chanl(0)->field_08 - 4;
 
     NEW_PRIM(lineF2, work);
 

--- a/source/menu/jimaku.c
+++ b/source/menu/jimaku.c
@@ -65,7 +65,7 @@ void menu_jimaku_act( MenuWork *work, unsigned int *pOt )
             config.ypos = 80;
 
             _menu_number_draw_string2( work->field_20_otBuf, &config, "PAUSE" );
-            pTile = menu_render_rect_8003DB2C( work->field_20_otBuf, 0, 0, 320, 224, 0 );
+            pTile = menu_render_rect_8003DB2C( work->field_20_otBuf, 0, 0, FRAME_WIDTH, FRAME_HEIGHT, 0 );
             setSemiTrans(pTile, 1);
         }
 
@@ -114,7 +114,7 @@ void menu_jimaku_act( MenuWork *work, unsigned int *pOt )
         gUnkJimakuStruct_800BDA70.field_8_w = 256;
         gUnkJimakuStruct_800BDA70.field_38_str = NULL;
         gUnkJimakuStruct_800BDA70.field_0_active = 1;
-        gUnkJimakuStruct_800BDA70.field_4_x = (320 - pFont->max_width) / 2;
+        gUnkJimakuStruct_800BDA70.field_4_x = (FRAME_WIDTH - pFont->max_width) / 2;
         gUnkJimakuStruct_800BDA70.field_A_h = pFont->short3;
         gUnkJimakuStruct_800BDA70.field_6_y = y - (pFont->short3 / 2);
     }

--- a/source/menu/menuman.c
+++ b/source/menu/menuman.c
@@ -116,12 +116,12 @@ void menu_init_subsystems_8003884C(MenuWork *work)
     gMenuPrimBuffer_8009E2D0.mPrimPtrs[0] = &gPrimBackingBuffers_800B9360[0][0];
     gMenuPrimBuffer_8009E2D0.mPrimPtrs[1] = &gPrimBackingBuffers_800B9360[1][0];
 
-    DG_InitDrawEnv(&drawEnv, 0, 0, 320, 224);
+    DG_InitDrawEnv(&drawEnv, 0, 0, FRAME_WIDTH, FRAME_HEIGHT);
     drawEnv.isbg = 0;
     drawEnv.tpage = 31;
     SetDrawEnv(&work->field_4C_drawEnv[0], &drawEnv);
 
-    DG_InitDrawEnv(&drawEnv, 320, 0, 320, 224);
+    DG_InitDrawEnv(&drawEnv, 320, 0, FRAME_WIDTH, FRAME_HEIGHT);
     drawEnv.isbg = 0;
     drawEnv.tpage = 31;
     SetDrawEnv(&work->field_4C_drawEnv[1], &drawEnv);

--- a/source/menu/radar.c
+++ b/source/menu/radar.c
@@ -8,6 +8,7 @@
 #include "game/game.h"
 #include "linkvar.h"
 #include "sd/g_sound.h"
+#include "psxdefs.h"    // for getScratchAddr2
 
 int MENU_RadarScale = 13;
 int MENU_RadarRangeH = 21845;
@@ -187,9 +188,6 @@ void drawBorder_800390FC(MenuWork *menuMan, unsigned char *ot)
     menu_render_rect_8003DB2C(menuMan->field_20_otBuf, x1 + 304, y2, 1, 54, 0); // Right border.
     menu_render_rect_8003DB2C(menuMan->field_20_otBuf, x2, y1 + 68, 70, 1, 0); // Bottom border.
 }
-
-/* scratch pad address 0x1f800000 - 0x1f800400 */
-#define getScratchAddr2(type, offset)   ((type *)(0x1f800000+(offset)))
 
 // clang-format off
 // gte_stbv but with sh instead of sb

--- a/source/menu/radio.c
+++ b/source/menu/radio.c
@@ -152,8 +152,8 @@ void FadeCodecScreen(MenuWork *work, unsigned char *pOt, int opacity)
 
     tile->x0 = 0;
     tile->y0 = 0;
-    tile->w = 320;
-    tile->h = 224;
+    tile->w = FRAME_WIDTH;
+    tile->h = FRAME_HEIGHT;
     addPrim(pOt, tile);
 
     NEW_PRIM(tpage, work);
@@ -804,7 +804,7 @@ int draw_radio_message(MenuWork *work, unsigned char *pOt)
     pPrim->w = 252;
     pPrim->h = 76;
     pPrim->clut = 32700;
-    pPrim->x0 = (320 - kcb->max_width) / 2;
+    pPrim->x0 = (FRAME_WIDTH - kcb->max_width) / 2;
     pPrim->y0 = 132;
 
     setSprt(pPrim);

--- a/source/okajima/stgfd_io.c
+++ b/source/okajima/stgfd_io.c
@@ -128,7 +128,7 @@ STATIC int stgfd_io_GetResources(StgfdIoWork *work)
     setTile(&pAlloc->tile[0]);
     setSemiTrans(&pAlloc->tile[0], 1);
     setXY0(&pAlloc->tile[0], -160, -112);
-    setWH(&pAlloc->tile[0], 320, 224);
+    setWH(&pAlloc->tile[0], FRAME_WIDTH, FRAME_HEIGHT);
 
     pAlloc->tile[1] = pAlloc->tile[0];
     setRGB0(&pAlloc->tile[0], 0, 0, 0);

--- a/source/okajima/stngrnd.c
+++ b/source/okajima/stngrnd.c
@@ -85,7 +85,7 @@ STATIC void stngrnd_Act(StunGrenadeWork *work)
 
     --work->alive_counter;
 
-    mtx = &DG_Chanl(0)->field_10_eye_inv;
+    mtx = &DG_Chanl(0)->eye_inv;
     SetRotMatrix(mtx);
     SetTransMatrix(mtx);
     RotTransPers(&work->field_E0, (u_long *)&screenCoords, &interp, &flag);
@@ -158,8 +158,8 @@ STATIC int stngrnd_GetResources(StunGrenadeWork *work, MATRIX *world)
 
     NewStnFade();
 
-    SetRotMatrix(&DG_Chanl(0)->field_10_eye_inv);
-    SetTransMatrix(&DG_Chanl(0)->field_10_eye_inv);
+    SetRotMatrix(&DG_Chanl(0)->eye_inv);
+    SetTransMatrix(&DG_Chanl(0)->eye_inv);
     RotTransPers(&work->field_E0, (long *)&xy, &p, &flag);
 
     for (i = 0; i < 8; i++)

--- a/source/overlays/_shared/chara/torture/boxall.c
+++ b/source/overlays/_shared/chara/torture/boxall.c
@@ -31,7 +31,7 @@ int Boxall_800C9780(SVECTOR *out, SVECTOR *in)
     int     z;
     MATRIX *m;
 
-    m = &DG_Chanl(0)->field_10_eye_inv;
+    m = &DG_Chanl(0)->eye_inv;
     gte_SetRotMatrix(m);
     gte_SetTransMatrix(m);
     gte_ldv0(in);
@@ -139,7 +139,7 @@ void Boxall_800C9A48(BoxallWork *work)
     SVECTOR pos;
     MATRIX *m;
 
-    m = &DG_Chanl(0)->field_10_eye_inv;
+    m = &DG_Chanl(0)->eye_inv;
     gte_SetRotMatrix(m);
     gte_SetTransMatrix(m);
     gte_ldv0(&work->control.mov);

--- a/source/overlays/_shared/chara/torture/boxall.c
+++ b/source/overlays/_shared/chara/torture/boxall.c
@@ -102,7 +102,7 @@ void Boxall_800C9800(BoxallWork *work)
     }
 
     y = MAX(y, 32);
-    y = MIN(y, 224);
+    y = MIN(y, FRAME_HEIGHT);
 
     line->x2 = line->x1 = x + 16;
     line->y2 = line->y1 = y - 16;

--- a/source/overlays/_shared/game/movie.c
+++ b/source/overlays/_shared/game/movie.c
@@ -217,7 +217,7 @@ static void Act2(MovieWork *work)
     rect->x = (GV_Clock == 0) ? 304 : -16;
     rect->y = 24;
     rect->w = 16;
-    rect->h = MIN(work->height, 224);
+    rect->h = MIN(work->height, FRAME_HEIGHT);
 
     work->f2C = 0;
     work->f38 = rect->x + work->width;

--- a/source/overlays/_shared/game/tobcnt.c
+++ b/source/overlays/_shared/game/tobcnt.c
@@ -454,7 +454,7 @@ static void DrawBackgroundFade(Work *work, u_long *ot, int shade)
     setTile(tile);
     setSemiTrans(tile, 1);
     setXY0(tile, 0, 0);
-    setWH(tile, 320, 240);
+    setWH(tile, SCREEN_WIDTH, SCREEN_HEIGHT);
     addPrim(ot, tile);
 
     tpage = &work->fade_tpage[GV_Clock];

--- a/source/overlays/_shared/kojo/inverlt2.c
+++ b/source/overlays/_shared/kojo/inverlt2.c
@@ -264,8 +264,8 @@ static void InitRects(Work *work, int scale)
     short   screen;
 
 
-    SetRotMatrix(&DG_Chanl(0)->field_10_eye_inv);
-    SetTransMatrix(&DG_Chanl(0)->field_10_eye_inv);
+    SetRotMatrix(&DG_Chanl(0)->eye_inv);
+    SetTransMatrix(&DG_Chanl(0)->eye_inv);
     RotTransPers(&work->fE0, (long *)&sxy, &p, &flag);
 
     if (sxy.vy == 0)

--- a/source/overlays/_shared/okajima/blur.c
+++ b/source/overlays/_shared/okajima/blur.c
@@ -48,7 +48,7 @@ void d01a_blur_800CCB28(void)
     DR_STP       *stp;
     DR_STP       *stp2;
 
-    ot = (unsigned int *)DG_Chanl(0)->mOrderingTables[GV_Clock];
+    ot = (unsigned int *)DG_Chanl(0)->ot[GV_Clock];
 
     tile = &d01a_dword_800D1428[GV_Clock];
     SetTile(tile);
@@ -62,7 +62,7 @@ void d01a_blur_800CCB28(void)
     SetDrawStp(stp, 1);
     addPrim(&ot[0xFF], stp);
 
-    ot = (unsigned int *)DG_Chanl(1)->mOrderingTables[GV_Clock];
+    ot = (unsigned int *)DG_Chanl(1)->ot[GV_Clock];
 
     stp2 = &d01a_dword_800D1468[GV_Clock];
     SetDrawStp(stp2, 1);

--- a/source/overlays/_shared/okajima/blur.c
+++ b/source/overlays/_shared/okajima/blur.c
@@ -54,7 +54,7 @@ void d01a_blur_800CCB28(void)
     SetTile(tile);
     setSemiTrans(tile, 1);
     setXY0(tile, -160, -112);
-    setWH(tile, 320, 224);
+    setWH(tile, FRAME_WIDTH, FRAME_HEIGHT);
     DG_SetBackGroundTile(tile);
     addPrim(&ot[0xFF], tile);
 
@@ -149,11 +149,11 @@ void d01a_blur_800CCCC8(POLY_FT4 *packs, BlurWork *work, int arg3, int abr, int 
 
     packs2->x0 = packs1->x1;
     packs2->y0 = packs1->y1;
-    packs2->x1 = -xoff + 320 - work->f64;
+    packs2->x1 = -xoff + FRAME_WIDTH - work->f64;
     packs2->y1 = (work->f68 + yoff);
     packs2->x2 = packs1->x3;
     packs2->y2 = packs1->y3;
-    packs2->x3 = -xoff + 320 - work->f64;
+    packs2->x3 = -xoff + FRAME_WIDTH - work->f64;
     packs2->y3 = work->f74 + (rnd2[2] + 112);
 
     packs3->x0 = packs1->x2;
@@ -161,9 +161,9 @@ void d01a_blur_800CCCC8(POLY_FT4 *packs, BlurWork *work, int arg3, int abr, int 
     packs3->x1 = packs1->x3;
     packs3->y1 = packs1->y3;
     packs3->x2 = work->f64 + xoff;
-    packs3->y2 = -yoff + 224 - work->f6C;
+    packs3->y2 = -yoff + FRAME_HEIGHT - work->f6C;
     packs3->x3 = work->f70 + (rnd1[2] + 160);
-    packs3->y3 = -yoff + 224 - work->f6C;
+    packs3->y3 = -yoff + FRAME_HEIGHT - work->f6C;
 
     packs4->x0 = packs1->x3;
     packs4->y0 = packs1->y3;
@@ -173,8 +173,8 @@ void d01a_blur_800CCCC8(POLY_FT4 *packs, BlurWork *work, int arg3, int abr, int 
     packs4->y2 = packs3->y3;
     c159_2 = 159;
     asm(""); // FIXME
-    packs4->x3 = -xoff + 320 - work->f64;
-    packs4->y3 = -yoff + 224 - work->f6C;
+    packs4->x3 = -xoff + FRAME_WIDTH - work->f64;
+    packs4->y3 = -yoff + FRAME_HEIGHT - work->f6C;
 
     packs1->u0 = packs1->u2 = work->f64 + 2;
     c111_2 = 111;

--- a/source/overlays/_shared/okajima/blurpure.c
+++ b/source/overlays/_shared/okajima/blurpure.c
@@ -38,7 +38,7 @@ void d03a_blurpure_800C4F68(BlurPureWork *work)
     DR_STP        *stp;
     unsigned char *pOt;
 
-    pOt = DG_Chanl(0)->mOrderingTables[GV_Clock]; // DG_ChanlOTag doesn't work here
+    pOt = DG_Chanl(0)->ot[GV_Clock]; // DG_ChanlOTag doesn't work here
     tile = &work->field_20->tile[GV_Clock];
 
     setTile(tile);
@@ -55,7 +55,7 @@ void d03a_blurpure_800C4F68(BlurPureWork *work)
     SetDrawStp(stp, 1);
     addPrim(pOt + 4 * 0xFF, stp); // TODO: what's this offset 0x3CF = 4 * 0xFF?
 
-    pOt = DG_Chanl(1)->mOrderingTables[GV_Clock];
+    pOt = DG_Chanl(1)->ot[GV_Clock];
     stp = &work->field_20->stp2[GV_Clock];
     SetDrawStp(stp, 1);
     addPrim(pOt, stp);
@@ -105,7 +105,7 @@ void d03a_blurpure_800C51A8(BlurPureWork *work)
     unsigned char *pOt;
 
     sprt = &work->field_20->sprt1[GV_Clock];
-    pOt = DG_Chanl(0)->mOrderingTables[GV_Clock];
+    pOt = DG_Chanl(0)->ot[GV_Clock];
     SetSprt(sprt);
     sprt->r0 = 0x78;
     sprt->g0 = 0x78;

--- a/source/overlays/_shared/okajima/blurpure.c
+++ b/source/overlays/_shared/okajima/blurpure.c
@@ -44,8 +44,8 @@ void d03a_blurpure_800C4F68(BlurPureWork *work)
     setTile(tile);
     tile->x0 = -160;
     tile->y0 = -112;
-    tile->w = 320;
-    tile->h = 224;
+    tile->w = FRAME_WIDTH;
+    tile->h = FRAME_HEIGHT;
     tile->r0 = 0;
     tile->g0 = 0;
     tile->b0 = 0;

--- a/source/overlays/_shared/okajima/p_lamp.c
+++ b/source/overlays/_shared/okajima/p_lamp.c
@@ -41,7 +41,7 @@ typedef struct PLampWork
 SVECTOR p_lamp_target_svec_800C353C = {5, 5, 5};
 RECT    p_lamp_prim_rect_800C3544 = {100, 100, 200, 200};
 
-extern DG_CHANL DG_Chanls_800B1800[3];
+extern DG_CHANL DG_Chanls[3];
 
 void PLampLookAt_800CC9F4(PLampWork *work, SVECTOR *eye, SVECTOR *center)
 {
@@ -60,7 +60,7 @@ void PLampLookAt_800CC9F4(PLampWork *work, SVECTOR *eye, SVECTOR *center)
 
     GM_PadVibration = GV_RandU(2);
     GM_PadVibration2 = work->field_1CC * 255 / 42;
-    DG_LookAt(&DG_Chanls_800B1800[1], eye, center, 320);
+    DG_LookAt(&DG_Chanls[1], eye, center, 320);
 }
 
 void PLamp_800CCBA8(POLY_FT4 *poly, DG_TEX *tex, int r, int g, int b)

--- a/source/overlays/_shared/okajima/pato_lmp.c
+++ b/source/overlays/_shared/okajima/pato_lmp.c
@@ -960,8 +960,8 @@ temp_label_end4:
     setSemiTrans(&prims->tile[0], 1);
     prims->tile[0].x0 = -160;
     prims->tile[0].y0 = -112;
-    prims->tile[0].w = 320;
-    prims->tile[0].h = 224;
+    prims->tile[0].w = FRAME_WIDTH;
+    prims->tile[0].h = FRAME_HEIGHT;
 
     prims->tile[1] = prims->tile[0];
 

--- a/source/overlays/_shared/okajima/red_alrt.c
+++ b/source/overlays/_shared/okajima/red_alrt.c
@@ -302,8 +302,8 @@ int d03a_red_alrt_800C4958(RedAlrtWork *work, int name, int map)
 
     prims->tile[0].x0 = -160;
     prims->tile[0].y0 = -112;
-    prims->tile[0].w = 320;
-    prims->tile[0].h = 224;
+    prims->tile[0].w = FRAME_WIDTH;
+    prims->tile[0].h = FRAME_HEIGHT;
 
     prims->tile[1] = prims->tile[0];
 
@@ -368,8 +368,8 @@ int d03a_red_alrt_800C4BB0(RedAlrtWork *work, int name, int length, SVECTOR *col
 
     prims->tile[0].x0 = -160;
     prims->tile[0].y0 = -112;
-    prims->tile[0].w = 320;
-    prims->tile[0].h = 224;
+    prims->tile[0].w = FRAME_WIDTH;
+    prims->tile[0].h = FRAME_HEIGHT;
 
     prims->tile[1] = prims->tile[0];
 

--- a/source/overlays/_shared/onoda/change/change.c
+++ b/source/overlays/_shared/onoda/change/change.c
@@ -604,7 +604,7 @@ static void Act( Work *work )
     }
 
     change_800C3B90( work );
-    Change_800C38D0( work, DG_Chanl(1)->mOrderingTables[ GV_Clock ] );
+    Change_800C38D0( work, DG_Chanl(1)->ot[ GV_Clock ] );
     change_800C3CD0( work );
 
     if ( work->f6BC == 0 && work->f6A0 >= 160 )

--- a/source/overlays/_shared/onoda/change/met_logo.c
+++ b/source/overlays/_shared/onoda/change/met_logo.c
@@ -393,7 +393,7 @@ static void DrawBackgroundFade( Work *work, u_long *ot, int shade )
     setTile( tile );
     setSemiTrans( tile, 1 );
     setXY0( tile, 0, 0 );
-    setWH( tile, 320, 240 );
+    setWH( tile, SCREEN_WIDTH, SCREEN_HEIGHT );
     addPrim( ot, tile );
 
     tpage = &work->fade_tpage[ GV_Clock ];

--- a/source/overlays/_shared/takabe/cinema.c
+++ b/source/overlays/_shared/takabe/cinema.c
@@ -195,8 +195,8 @@ static int GetResources( Work *work, int time, int event )
     setSemiTrans(poly, 1);
 
     colour = *(int*)&poly->r0;
-    poly->x1 = 320;
-    poly->x3 = 320;
+    poly->x1 = FRAME_WIDTH;
+    poly->x3 = FRAME_WIDTH;
     poly->x0 = 0;
     poly->y0 = 0;
     poly->y1 = 0;
@@ -213,17 +213,17 @@ static int GetResources( Work *work, int time, int event )
     prims->poly[0][1] = prims->poly[0][0];
 
     poly++;
-    poly->y0 = 224;
-    poly->y1 = 224;
-    poly->y2 = 224 - h2;
-    poly->y3 = 224 - h2;
+    poly->y0 = FRAME_HEIGHT;
+    poly->y1 = FRAME_HEIGHT;
+    poly->y2 = FRAME_HEIGHT - h2;
+    poly->y3 = FRAME_HEIGHT - h2;
 
     prims->poly[1][0] = prims->poly[0][0];
     prims->poly[1][1] = prims->poly[0][1];
 
     tile = (TILE*)prims->tile;
     setTile(tile);
-    tile->w = 320;
+    tile->w = FRAME_WIDTH;
     tile->x0 = 0;
     tile->y0 = 0;
     tile->h = h1;
@@ -231,7 +231,7 @@ static int GetResources( Work *work, int time, int event )
 
     params = work->params;
     prims->tile[0][1] = prims->tile[0][0];
-    tile[1].y0 = 224-h2;
+    tile[1].y0 = FRAME_HEIGHT-h2;
     col = 384;
     tile[1].h = h2;
 

--- a/source/overlays/_shared/takabe/cinema.c
+++ b/source/overlays/_shared/takabe/cinema.c
@@ -70,7 +70,7 @@ static void Act( Work *work )
         return;
     }
 
-    ot = (u_long *)DG_Chanl( 1 )->mOrderingTables[ GV_Clock ] ;
+    ot = (u_long *)DG_Chanl( 1 )->ot[ GV_Clock ] ;
 
     for ( i = 0 ; i < 2 ; i++ )
     {

--- a/source/overlays/_shared/takabe/ending2.c
+++ b/source/overlays/_shared/takabe/ending2.c
@@ -91,7 +91,11 @@ int roll_dword_800C3244 = 0x00FF0000;
 int roll_dword_800C3248 = 0x00010010;
 
 RECT ending2_orig_image_rect_800C324C = {640, 0, 320, 1};
-RECT moviework_rects_800C3254[3] = {{0, 320, 320, 160}, {320, 320, 320, 160}, {640, 320, 320, 160}};
+RECT moviework_rects_800C3254[3] = {
+    {   0, 320, 320, 160 },
+    { 320, 320, 320, 160 },
+    { 640, 320, 320, 160 }
+};
 
 Ending2MovieWork moviework_800C326C = {0};
 
@@ -584,7 +588,7 @@ void Ending2_800C6968(Ending2Work *work) // TODO: I guessed that it's work
     yoff = (work->field_24 + 320) % 320;
 
     ending2_image_rects_800C9ED0[GV_Clock] = ending2_orig_image_rect_800C324C;
-    ending2_image_rects_800C9ED0[GV_Clock].w = 320;
+    ending2_image_rects_800C9ED0[GV_Clock].w = FRAME_WIDTH;
     ending2_image_rects_800C9ED0[GV_Clock].h = 2;
     ending2_image_rects_800C9ED0[GV_Clock].y += yoff;
 
@@ -605,7 +609,7 @@ void roll_ending2_800C6AA4(Ending2Work *work, int count)
         yoff = (work->field_24 + 320 + i) % 320;
 
         ending2_800C9EE0[GV_Clock][i] = ending2_orig_image_rect_800C324C;
-        ending2_800C9EE0[GV_Clock][i].w = 320;
+        ending2_800C9EE0[GV_Clock][i].w = FRAME_WIDTH;
         ending2_800C9EE0[GV_Clock][i].h = 1;
         ending2_800C9EE0[GV_Clock][i].y += yoff;
 
@@ -650,14 +654,14 @@ void Ending2_800C6C9C(POLY_FT4 *polys, Ending2Pair *tpages, char *pOt)
 
     tpage = tpages->tpage1;
 
-    setXY4(scratch, 0, 0, 8, 0, 0, 320, 8, 320);
-    setUV4(scratch, 0, 64, 8, 64, 0, 224, 8, 224);
+    setXY4(scratch, 0, 0, 8, 0, 0, FRAME_WIDTH, 8, FRAME_WIDTH);
+    setUV4(scratch, 0, 64, 8, 64, 0, FRAME_HEIGHT, 8, FRAME_HEIGHT);
 
     scratch->tpage = tpage;
 
     x = 0;
     y = 0;
-    while (x < 320)
+    while (x < FRAME_WIDTH)
     {
         scratch->x0 = x;
         scratch->x2 = x;
@@ -704,13 +708,13 @@ void Ending2_800C6E00(SPRT *polys, Ending2Prims *prims, int arg2, char *pOt, int
     scratch[0].u0 = 0;
     scratch[0].v0 = 0;
     scratch[0].w = 8;
-    scratch[0].h = 0x100;
+    scratch[0].h = 256;
 
     setRGB0(&scratch[0], shade, shade, shade);
 
     scratch[2] = scratch[1] = scratch[0];
 
-    if (arg2 < 0x100)
+    if (arg2 < 256)
     {
         scratch[0].y0 = 0;
         scratch[0].v0 = arg2;
@@ -753,7 +757,7 @@ void Ending2_800C6E00(SPRT *polys, Ending2Prims *prims, int arg2, char *pOt, int
     u0 = 0;
 
     scratch2 = &scratch[1];
-    while (x0 < 320)
+    while (x0 < FRAME_WIDTH)
     {
         scratch2->x0 = x0;
         scratch[0].x0 = x0;
@@ -781,7 +785,7 @@ void Ending2_800C6E00(SPRT *polys, Ending2Prims *prims, int arg2, char *pOt, int
 
     x0 = 0;
     u0 = 0;
-    while (x0 < 320)
+    while (x0 < FRAME_WIDTH)
     {
         scratch[2].x0 = x0;
         x0 += 8;
@@ -976,7 +980,7 @@ void Ending2Die_800C76BC(Ending2Work *work)
     dispenv = DG_GetDisplayEnv();
     *dispenv = work->field_325C;
 
-    SetDefDrawEnv(&drawenv, 0, 0, 320, 224);
+    SetDefDrawEnv(&drawenv, 0, 0, FRAME_WIDTH, FRAME_HEIGHT);
 
     DG_SetRenderChanlDrawEnv(-1, &drawenv);
     DG_SetRenderChanlDrawEnv(1, &drawenv);

--- a/source/overlays/_shared/takabe/envmap3.c
+++ b/source/overlays/_shared/takabe/envmap3.c
@@ -178,7 +178,7 @@ void Envmap3_800CA0E4(DG_OBJ *obj)
         dirty = 1;
     }
 
-    MulMatrix0(&DG_Chanl(0)->field_10_eye_inv, &obj->world, &rot);
+    MulMatrix0(&DG_Chanl(0)->eye_inv, &obj->world, &rot);
     MulMatrix(&rot, &envmap3_scale);
     SetRotMatrix(&rot);
 

--- a/source/overlays/_shared/takabe/focus.c
+++ b/source/overlays/_shared/takabe/focus.c
@@ -124,7 +124,7 @@ int FocusGetResources_800CEDA4(FocusWork *work, int arg1, int arg2)
     setSprt(sprt);
     setSemiTrans(sprt, 1);
     setXY0(sprt, -160, -112);
-    setWH(sprt, 160, 224);
+    setWH(sprt, 160, FRAME_HEIGHT);
     setUV0(sprt, 0, 0);
     setRGB0(sprt, 128, 128, 128);
 

--- a/source/overlays/_shared/takabe/lit_mdl.c
+++ b/source/overlays/_shared/takabe/lit_mdl.c
@@ -63,7 +63,7 @@ DG_DEF litmdl_dg_def =
     }
 };
 
-extern DG_CHANL DG_Chanls_800B1800[3];
+extern DG_CHANL DG_Chanls[3];
 
 void s01a_lit_mdl_800E26EC(LitMdlWork *work)
 {
@@ -175,7 +175,7 @@ void s01a_lit_mdl_800E2928(LitMdlWork *work)
         s01a_lit_mdl_800E26EC(work);
     }
 
-    if (DG_Chanls_800B1800[1].field_30_eye.t[1] > work->field_AC)
+    if (DG_Chanls[1].eye.t[1] > work->field_AC)
     {
         DG_VisibleObjs(work->field_24_obj.objs);
     }

--- a/source/overlays/_shared/takabe/sepia.c
+++ b/source/overlays/_shared/takabe/sepia.c
@@ -17,7 +17,7 @@ typedef struct _SepiaWork
     SepiaPrims *prims;
 } SepiaWork;
 
-extern u_long DG_PaletteBuffer_800B3818[256];
+extern u_long DG_PaletteBuffer[256];
 
 RECT rect_800C3258 = {768, 226, 256, 2};
 RECT rect_800C3260 = {768, 196, 256, 2};
@@ -67,16 +67,16 @@ void s16b_800C4CD0(void)
     for (i = 15; i > 0; i--)
     {
         DrawSync(0);
-        StoreImage2(&rect_800C3260, DG_PaletteBuffer_800B3818);
+        StoreImage2(&rect_800C3260, DG_PaletteBuffer);
         DrawSync(0);
 
-        iter = (short *)DG_PaletteBuffer_800B3818;
+        iter = (short *)DG_PaletteBuffer;
         for (j = 512; j > 0; j--)
         {
             *iter++ = s16b_800C4C60(*iter);
         }
 
-        LoadImage2(&rect_800C3258, DG_PaletteBuffer_800B3818);
+        LoadImage2(&rect_800C3258, DG_PaletteBuffer);
 
         rect_800C3260.y += 2;
         rect_800C3258.y += 2;
@@ -197,16 +197,16 @@ void s16b_800C50EC(void)
     for (i = 15; i > 0; i--)
     {
         DrawSync(0);
-        StoreImage2(&rect_800C3270, DG_PaletteBuffer_800B3818);
+        StoreImage2(&rect_800C3270, DG_PaletteBuffer);
         DrawSync(0);
 
-        iter = (short *)DG_PaletteBuffer_800B3818;
+        iter = (short *)DG_PaletteBuffer;
         for (j = 512; j > 0; j--)
         {
             *iter++ = s16b_800C5074(*iter);
         }
 
-        LoadImage2(&rect_800C3268, DG_PaletteBuffer_800B3818);
+        LoadImage2(&rect_800C3268, DG_PaletteBuffer);
 
         rect_800C3270.y += 2;
         rect_800C3268.y += 2;

--- a/source/overlays/_shared/takabe/vib_edit.c
+++ b/source/overlays/_shared/takabe/vib_edit.c
@@ -142,7 +142,7 @@ STATIC void VibEdit_800C36BC(VibEditWork *work)
     x0 = 16;
 
     tile = work->field_44_prims->tiles1[GV_Clock];
-    mOt = DG_Chanl(1)->mOrderingTables[GV_Clock];
+    mOt = DG_Chanl(1)->ot[GV_Clock];
 
     for (i = 0; i < 16; i++, pairs++, tile++)
     {

--- a/source/overlays/_shared/takabe/wt_area.c
+++ b/source/overlays/_shared/takabe/wt_area.c
@@ -177,7 +177,7 @@ static void Act( Work *work )
         }
     }
 
-    eye = &DG_Chanl(0)->field_30_eye;
+    eye = &DG_Chanl(0)->eye;
     snake_pos.vx = eye->t[0];
     snake_pos.vy = eye->t[1];
     snake_pos.vz = eye->t[2];

--- a/source/overlays/_shared/takabe/wt_area2.c
+++ b/source/overlays/_shared/takabe/wt_area2.c
@@ -157,7 +157,7 @@ static void Act( Work *work )
         work->field_48 = 0;
     }
 
-    eye = &DG_Chanl(0)->field_30_eye;
+    eye = &DG_Chanl(0)->eye;
     snake_pos.vx = eye->t[0];
     snake_pos.vy = eye->t[1];
     snake_pos.vz = eye->t[2];

--- a/source/overlays/_shared/takabe/wt_view.c
+++ b/source/overlays/_shared/takabe/wt_view.c
@@ -23,7 +23,7 @@ typedef struct {
 extern void SetPriority(DR_PRIO *p, int pbc, int pbw);
 // clang-format on
 
-extern DG_CHANL DG_Chanls_800B1800[3];
+extern DG_CHANL DG_Chanls[3];
 
 /*---------------------------------------------------------------------------*/
 
@@ -142,7 +142,7 @@ static void Act(Work *work)
     ot = (u_long *)DG_ChanlOTag(0);
 
     vec = &sp10;
-    eye = &DG_Chanls_800B1800[1].field_30_eye;
+    eye = &DG_Chanls[1].eye;
 
     vec->vx = x = eye->t[0];
     vec->vy = y = eye->t[1];

--- a/source/overlays/_shared/takabe/wt_view.c
+++ b/source/overlays/_shared/takabe/wt_view.c
@@ -299,8 +299,8 @@ static int WaterViewCreatePrims(Work *work)
     tile = &work->prims->tile[0];
     SetTile(tile);
 
-    tile->x0 = -160;
-    tile->w = 320;
+    tile->x0 = -(FRAME_WIDTH/2);
+    tile->w = FRAME_WIDTH;
     tile->h = 6;
 
     tile->r0 = 0;
@@ -318,10 +318,10 @@ static int WaterViewCreatePrims(Work *work)
     tile2 = &work->prims->tile2[0];
     setTile(tile2);
 
-    tile2->x0 = -160;
-    tile2->y0 = -112;
-    tile2->w = 320;
-    tile2->h = 224;
+    tile2->x0 = -(FRAME_WIDTH/2);
+    tile2->y0 = -(FRAME_HEIGHT/2);
+    tile2->w = FRAME_WIDTH;
+    tile2->h = FRAME_HEIGHT;
 
     tile2->r0 = 0;
     tile2->g0 = 0;

--- a/source/overlays/_shared/thing/sphere.c
+++ b/source/overlays/_shared/thing/sphere.c
@@ -250,8 +250,8 @@ static int GetResources(Work *work, int map)
         *textures++ = DG_GetTexture(name);
     }
 
-    sphere_visible_tiles_x = (320 / sphere_tile_width) + 1;
-    sphere_visible_tiles_y = (224 / sphere_tile_height) + 1;
+    sphere_visible_tiles_x = (FRAME_WIDTH / sphere_tile_width) + 1;
+    sphere_visible_tiles_y = (FRAME_HEIGHT / sphere_tile_height) + 1;
     n_prims = sphere_visible_tiles_y * sphere_visible_tiles_x;
 
     prim = DG_GetPrim(DG_PRIM_SORTONLY | DG_PRIM_POLY_FT4, n_prims, 0, NULL, NULL);

--- a/source/overlays/_shared/thing/sphere.c
+++ b/source/overlays/_shared/thing/sphere.c
@@ -68,7 +68,7 @@ static void Act(Work *work)
     short         *poly_tag;
     long           tile_height, tile_width;
 
-    Sphere_800C60E0(&DG_Chanl(0)->field_30_eye, &svec);
+    Sphere_800C60E0(&DG_Chanl(0)->eye, &svec);
 
     if (work->f68 > 0)
     {

--- a/source/overlays/camera/unknown/camera.c
+++ b/source/overlays/camera/unknown/camera.c
@@ -916,7 +916,7 @@ void camera_800C85D8(void)
 void CameraAct_800CE404(CameraWork *work)
 {
     work->field_920 = work->field_92C[GV_Clock];
-    work->field_924_mOrderingTable = DG_Chanl(1)->mOrderingTables[GV_Clock];
+    work->field_924_mOrderingTable = DG_Chanl(1)->ot[GV_Clock];
     camera_800CDF18(work);
     camera_800C3ED8(work);
     work->field_4938++;

--- a/source/overlays/s11g/kojo/hind.c
+++ b/source/overlays/s11g/kojo/hind.c
@@ -279,7 +279,7 @@ SVECTOR s11g_dword_800C3598 = {5000, 3000, 5000, 0};
 SVECTOR s11g_dword_800C35A0 = {100, 0, 0, 0};
 
 extern UnkCameraStruct2 gUnkCameraStruct2_800B7868;
-extern DG_CHANL         DG_Chanls_800B1800[3];
+extern DG_CHANL         DG_Chanls[3];
 extern GM_CAMERA        GM_Camera;
 
 void HindAct_800D3404(HindWork *work);
@@ -961,7 +961,7 @@ void *NewHind_800D1224(int scriptData, int scriptBinds)
 
 void Hind_LookAt_800D2C1C(SVECTOR *eye, SVECTOR *center)
 {
-    DG_LookAt(&DG_Chanls_800B1800[1], eye, center, 320);
+    DG_LookAt(&DG_Chanls[1], eye, center, 320);
     GM_Camera.field_2A = 0;
     gUnkCameraStruct2_800B7868.eye = *eye;
     gUnkCameraStruct2_800B7868.center = *center;

--- a/source/overlays/s12a/okajima/wolf/wolf2.c
+++ b/source/overlays/s12a/okajima/wolf/wolf2.c
@@ -667,7 +667,7 @@ int wolf2_GetResources2(Wolf2Work *work, int name, int where)
     setTile(&alloc->tile[0]);
     setSemiTrans(&alloc->tile[0], 1);
     setXY0(&alloc->tile[0], -160, -112);
-    setWH(&alloc->tile[0], 320, 224);
+    setWH(&alloc->tile[0], FRAME_WIDTH, FRAME_HEIGHT);
 
     alloc->tile[1] = alloc->tile[0];
 

--- a/source/overlays/s12c/takabe/findtrap.c
+++ b/source/overlays/s12c/takabe/findtrap.c
@@ -38,7 +38,7 @@ TGMCameraFunc SECTION("overlay.bss") s12c_dword_800DAA94;
 extern GM_CAMERA       GM_Camera;
 extern UnkCameraStruct gUnkCameraStruct_800B77B8;
 extern int             dword_8009F470;
-extern DG_CHANL        DG_Chanls_800B1800[3];
+extern DG_CHANL        DG_Chanls[3];
 
 void FindTrap_callback1_800D7908();
 void FindTrap_callback2_800D7870();
@@ -82,7 +82,7 @@ void s12c_findtrap_800D72E8(FindTrapWork *work)
                 SVECTOR *field_30;
                 int      field_40;
 
-                eye_inv = DG_Chanl(0)->field_10_eye_inv;
+                eye_inv = DG_Chanl(0)->eye_inv;
 
                 DG_AdjustOverscan(&eye_inv);
                 DG_SetPos(&eye_inv);

--- a/source/overlays/s12c/takabe/libdg2.c
+++ b/source/overlays/s12c/takabe/libdg2.c
@@ -434,7 +434,7 @@ void FogSortChanl_800D4E98(DG_CHANL *chanl, int idx)
 
     scratch = get_scratch();
     scratch->buf = ptr_800B1400;
-    scratch->ot = (unsigned int *)chanl->mOrderingTables[idx] + 1;
+    scratch->ot = (unsigned int *)chanl->ot[idx] + 1;
 
     s12c_800D4CF4(scratch->ot);
 
@@ -727,7 +727,7 @@ void FogBoundChanl_800D5500(DG_CHANL *chanl, int idx)
     unsigned int flag;
     short       *scrpad;
 
-    DG_Clip(&chanl->field_5C_clip_rect, chanl->field_50_clip_distance);
+    DG_Clip(&chanl->clip_rect, chanl->clip_distance);
 
     scrpad = (short *)SCRPAD_ADDR;
     memcpy(scrpad + 0x90 / 2, DG_ClipMax, 4);
@@ -1383,7 +1383,7 @@ void FogTransChanl_800D63B0(DG_CHANL *chanl, int idx)
     DG_OBJ   *pParent;
     short     uVar1;
 
-    DG_Clip(&chanl->field_5C_clip_rect, chanl->field_50_clip_distance);
+    DG_Clip(&chanl->clip_rect, chanl->clip_distance);
 
     ppObjs = (DG_OBJS **)chanl->mQueue;
 

--- a/source/overlays/title/koba/vr/vrwindow.c
+++ b/source/overlays/title/koba/vr/vrwindow.c
@@ -469,8 +469,8 @@ void *NewVrwindow_800D81AC(int name, int where)
             }
 
             work->f28.h = (work->f40 * 18) + 18;
-            work->f28.x = (320 - work->f28.w) >> 1;
-            work->f28.y = (224 - work->f28.h) >> 1;
+            work->f28.x = (FRAME_WIDTH - work->f28.w) >> 1;
+            work->f28.y = (FRAME_HEIGHT - work->f28.h) >> 1;
         }
         else
         {

--- a/source/takabe/goggle.c
+++ b/source/takabe/goggle.c
@@ -9,7 +9,7 @@
 #include "scn_mask.h"
 
 extern int DG_CurrentGroupID;
-extern u_long DG_PaletteBuffer_800B3818[256];
+extern u_long DG_PaletteBuffer[256];
 
 /*---------------------------------------------------------------------------*/
 // night vision goggles (screen effect)
@@ -81,16 +81,16 @@ static void PaletteCallback(void)
 
     for (i = 15; i > 0; i--) {
         DrawSync(0);
-        StoreImage2(&rect_8009F70C, DG_PaletteBuffer_800B3818);
+        StoreImage2(&rect_8009F70C, DG_PaletteBuffer);
         DrawSync(0);
 
-        ptr = (u_short *)DG_PaletteBuffer_800B3818;
+        ptr = (u_short *)DG_PaletteBuffer;
 
         for (j = 512; j > 0; j--) {
             *ptr++ = PaletteConvert(*ptr);
         }
 
-        LoadImage2(&rect_8009F704, DG_PaletteBuffer_800B3818);
+        LoadImage2(&rect_8009F704, DG_PaletteBuffer);
 
         rect_8009F70C.y += 2;
         rect_8009F704.y += 2;

--- a/source/takabe/goggleir.c
+++ b/source/takabe/goggleir.c
@@ -11,7 +11,7 @@
 
 extern int DG_CurrentGroupID;
 extern int dword_800BDFA8;
-extern u_long DG_PaletteBuffer_800B3818[256];
+extern u_long DG_PaletteBuffer[256];
 
 /*---------------------------------------------------------------------------*/
 // thermal goggles (screen effect)
@@ -93,10 +93,10 @@ static void PaletteCallback(void)
     for (i = 15; i > 0; i--)
     {
         DrawSync(0);
-        StoreImage2(&rect_8009F720, DG_PaletteBuffer_800B3818);
+        StoreImage2(&rect_8009F720, DG_PaletteBuffer);
         DrawSync(0);
 
-        ptr = (u_short *)DG_PaletteBuffer_800B3818;
+        ptr = (u_short *)DG_PaletteBuffer;
 
         for (j = 512; j > 0; j--)
         {
@@ -106,7 +106,7 @@ static void PaletteCallback(void)
         if (i == 1)
         {
             color = PaletteConvert(0xffff);
-            ptr = (u_short *)&DG_PaletteBuffer_800B3818[248];
+            ptr = (u_short *)&DG_PaletteBuffer[248];
 
             for (j = 16; j > 0; j--)
             {
@@ -114,7 +114,7 @@ static void PaletteCallback(void)
             }
         }
 
-        LoadImage2(&rect_8009F718, DG_PaletteBuffer_800B3818);
+        LoadImage2(&rect_8009F718, DG_PaletteBuffer);
 
         rect_8009F720.y += 2;
         rect_8009F718.y += 2;

--- a/source/takabe/palette.c
+++ b/source/takabe/palette.c
@@ -6,7 +6,7 @@
 extern void (*pfn_800BDFB0)();
 extern unsigned short (*pfn_800BDFB4)(unsigned short);
 
-extern u_long DG_PaletteBuffer_800B3818[256];
+extern u_long DG_PaletteBuffer[256];
 
 /*---------------------------------------------------------------------------*/
 
@@ -17,7 +17,7 @@ STATIC RECT takabe_palette2 = { 768, 196, 256, 2 };
 
 void DG_StorePalette2(void)
 {
-    StoreImage(&takabe_palette2, DG_PaletteBuffer_800B3818);
+    StoreImage(&takabe_palette2, DG_PaletteBuffer);
 }
 
 void DG_StorePaletteEffect(void)
@@ -29,9 +29,9 @@ void DG_StorePaletteEffect(void)
     for (i = 15; i > 0; i--)
     {
         DrawSync(0);
-        StoreImage2(&rect2, DG_PaletteBuffer_800B3818);
+        StoreImage2(&rect2, DG_PaletteBuffer);
         DrawSync(0);
-        LoadImage2(&rect1, DG_PaletteBuffer_800B3818);
+        LoadImage2(&rect1, DG_PaletteBuffer);
         rect2.y += 2;
         rect1.y += 2;
     }
@@ -65,17 +65,17 @@ void sub_80079004(u_short param_1)
     for (i = 15; i > 0; i--)
     {
         DrawSync(0);
-        StoreImage2(&rect, DG_PaletteBuffer_800B3818);
+        StoreImage2(&rect, DG_PaletteBuffer);
         DrawSync(0);
 
-        ptr = (u_short *)DG_PaletteBuffer_800B3818;
+        ptr = (u_short *)DG_PaletteBuffer;
 
         for (j = 512; j > 0; j--)
         {
             *ptr++ = modify_data(*ptr, param_1);
         }
 
-        LoadImage2(&rect, DG_PaletteBuffer_800B3818);
+        LoadImage2(&rect, DG_PaletteBuffer);
         rect.y += 2;
     }
 }

--- a/source/takabe/prim.c
+++ b/source/takabe/prim.c
@@ -8,7 +8,7 @@
 #include "common.h"
 #include "libdg/libdg.h"
 
-extern DG_CHANL DG_Chanls_800B1800[3];
+extern DG_CHANL DG_Chanls[3];
 
 /*---------------------------------------------------------------------------*/
 
@@ -25,7 +25,7 @@ static POLY_FT4 *MakeIndividualRect3DPrimHandler(DG_PRIM *prim, POLY_FT4 *packs,
     verts = prim->vertices;
     in = (SVECTOR *)getScratchAddr(0);
 
-    clip_dist = DG_Chanls_800B1800[1].field_50_clip_distance;
+    clip_dist = DG_Chanls[1].clip_distance;
 
     while (--n_packs >= 0)
     {

--- a/source/thing/sgtrect3.c
+++ b/source/thing/sgtrect3.c
@@ -81,9 +81,9 @@ static void addPrimEX(u_long *ot, void *prim)
 
 static void sgtrect3_act_helper_8007009C(void)
 {
-    DG_Clip(&DG_Chanl(0)->field_5C_clip_rect, DG_Chanl(0)->field_50_clip_distance);
-    SetRotMatrix(&DG_Chanl(0)->field_10_eye_inv);
-    SetTransMatrix(&DG_Chanl(0)->field_10_eye_inv);
+    DG_Clip(&DG_Chanl(0)->clip_rect, DG_Chanl(0)->clip_distance);
+    SetRotMatrix(&DG_Chanl(0)->eye_inv);
+    SetTransMatrix(&DG_Chanl(0)->eye_inv);
 }
 
 static unsigned int sgtrect3_act_helper_helper_800700E0(TARGET *target, DVECTOR *vector)

--- a/source/weapon/rifle.c
+++ b/source/weapon/rifle.c
@@ -61,7 +61,7 @@ static int GetZoomLimit(void)
 
     if ((GM_GameStatus < 0) || !GM_PlayerControl)
     {
-        eye = &DG_Chanl(0)->field_30_eye;
+        eye = &DG_Chanl(0)->eye;
     }
     else
     {

--- a/source/weapon/stnsight.c
+++ b/source/weapon/stnsight.c
@@ -303,9 +303,9 @@ static void SetMissileRect( Work *work, u_long *ot )
 
         lines = work->field_38_lines_2Array[GV_Clock];
 
-        DG_Clip(&DG_Chanl(0)->field_5C_clip_rect, DG_Chanl(0)->field_50_clip_distance);
-        SetRotMatrix(&DG_Chanl(0)->field_10_eye_inv);
-        SetTransMatrix(&DG_Chanl(0)->field_10_eye_inv);
+        DG_Clip(&DG_Chanl(0)->clip_rect, DG_Chanl(0)->clip_distance);
+        SetRotMatrix(&DG_Chanl(0)->eye_inv);
+        SetTransMatrix(&DG_Chanl(0)->eye_inv);
         RotTransPers(&svector_8009F494, (long *)&sxy, &p, &flag);
 
         sx = sxy.vx;

--- a/source/weapon/stnsight.c
+++ b/source/weapon/stnsight.c
@@ -311,37 +311,36 @@ static void SetMissileRect( Work *work, u_long *ot )
         sx = sxy.vx;
         sy = sxy.vy;
 
-        x = sx + 0xa0;
-        y = sy + 0x70;
+        x = sx + 160;
+        y = sy + 112;
 
-        if (x >= 320u || y < 0 || y >= 224)
+        if (x >= (unsigned)FRAME_WIDTH || y < 0 || y >= FRAME_HEIGHT)
         {
             return;
         }
 
-        lines->x3 = sx + 0x9f;
-        lines->x0 = sx + 0x9f;
-        lines->x2 = sx + 0x8d;
-        lines->x1 = sx + 0x8d;
-        lines->y1 = sy + 0x62;
-        lines->y0 = sy + 0x62;
-        lines->y3 = sy + 0x7e;
-        lines->y2 = sy + 0x7e;
+        lines->x3 = sx + 159;
+        lines->x0 = sx + 159;
+        lines->x2 = sx + 141;
+        lines->x1 = sx + 141;
+        lines->y1 = sy + 98;
+        lines->y0 = sy + 98;
+        lines->y3 = sy + 126;
+        lines->y2 = sy + 126;
         addPrimEX( ot, lines );
         lines++;
 
-        lines->x3 = sx + 0xa1;
-        lines->x0 = sx + 0xa1;
-        lines->x2 = sx + 0xb3;
-        lines->x1 = sx + 0xb3;
-        lines->y1 = sy + 0x62;
-        lines->y0 = sy + 0x62;
-        lines->y3 = sy + 0x7e;
-        lines->y2 = sy + 0x7e;
-
+        lines->x3 = sx + 161;
+        lines->x0 = sx + 161;
+        lines->x2 = sx + 179;
+        lines->x1 = sx + 179;
+        lines->y1 = sy + 98;
+        lines->y0 = sy + 98;
+        lines->y3 = sy + 126;
+        lines->y2 = sy + 126;
         addPrimEX( ot, lines );
 
-        MENU_Locate(sx + 0x8d, sy + 0x7f, 0);
+        MENU_Locate(sx + 141, sy + 127, 0);
         MENU_Color(29, 41, 41);
 
         if ((GM_PlayerStatus & PLAYER_NOT_SIGHT) == 0)


### PR DESCRIPTION
- GM_GetCharaID can be written with nested for-loops instead of the double do-while we have currently. The inner loop was definitely a for-loop originally, since it checks the condition both before **and** after it executes. The outer loop seemed like an optimized for-loop since ``i`` being initialized to zero means it will always pass the condition on the first interation. Nothing against do-while but it seems cleaner this way.
- Use screen/frame width/height constants in various assignments and expressions where it makes sense. The PAL versions apparently use a different value for the screen height so this will need redefinition if the PAL code is ever decompiled.
- Added ``#if 0``'d code for DG_ChangeReso used in the PAL versions, decompiled by @KieronJ.
- Named GV_ACT's unused ``runtime`` and ``count`` fields, as they're equivalent to MGS4's.
- Renamed GCL NOT and ASSIGN operator constants for better clarity.
- ``getScratchAddr2`` was defined in two places and is generic enough to go in psxdefs.h, and now we have more than one thing in that header. Probably could've gone in common.h or we could move the other scratchpad defs into psxdefs.h but I'm not interested in doing that right now.